### PR TITLE
copy and paste relevant docs from pdc_describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # tiger-data-app
 TigerData is a comprehensive set of data storage and management tools and services that provides storage capacity, reliability, functionality, and performance to meet the needs of a rapidly changing research landscape and to enable new opportunities for leveraging the power of institutional data. 
+
+[![CircleCI](https://circleci.com/gh/pulibrary/tiger-data-app/tree/main.svg?style=svg)](https://circleci.com/gh/pulibrary/tiger-data-app/tree/main)
+[![Coverage Status](https://coveralls.io/repos/github/pulibrary/tiger-data-app/badge.svg?branch=main)](https://coveralls.io/github/pulibrary/tiger-data-app?branch=main)
+
+## Local development
+
+### Setup
+1. Check out code and `cd`
+1. Install tool dependencies
+    1. [Lando](https://docs.lando.dev/getting-started/installation.html)
+    1. [asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)
+1. Install asdf dependencies
+    1. `asdf plugin add ruby`
+    1. `asdf plugin add node`
+    1. `asdf plugin add yarn`
+    1. `asdf install`
+    1. ... but because asdf is not a dependency manager, if there are errors, you may need to install other dependencies. For example: `brew install gpg`
+1. Install language-specific dependencies
+    1. `bundle install`
+    1. `yarn install`
+
+### Starting / stopping services
+We use lando to run services required for both test and development environments.
+
+Start and initialize database services with:
+
+`bundle exec rake servers:start`
+
+To stop database services:
+
+`bundle exec rake servers:stop` or `lando stop`
+
+### Running tests
+1. Fast: `bundle exec rspec spec`
+2. Run in browser: `RUN_IN_BROWSER=true bundle exec rspec spec`
+
+### Starting the development server
+1. `bundle exec rails s -p 3000`
+2. Access application at [http://localhost:3000/](http://localhost:3000/)
+
+


### PR DESCRIPTION
- I've cut out the list of exact version numbers for ruby and node: That is redundant with tool-versions.
- I haven't included the end of the original readme, including the part about using the rails console to elevate privs; Not clear if that will be used here.

If this seems relevant for any project following this template, I'll follow-up with a PR for rails-template.