### PR TITLE
Copy and paste write_version task as suggested by rails-template

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,3 +8,13 @@ set :repo_url, "https://github.com/pulibrary/tiger-data-app.git"
 set :deploy_to, "/opt/tigerdata"
 
 set :branch, ENV["BRANCH"] || "main"
+
+desc "Write the current version to public/version.txt"
+task :write_version do
+  on roles(:app), in: :sequence do
+    within repo_path do
+      execute :tail, "-n1 ../revisions.log > #{release_path}/public/version.txt"
+    end
+  end
+end
+after 'deploy:log_revision', 'write_version'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,4 +17,4 @@ task :write_version do
     end
   end
 end
-after 'deploy:log_revision', 'write_version'
+after "deploy:log_revision", "write_version"


### PR DESCRIPTION
- Fix #31

This is part of the setup instructions in rails-template, but it is in place only [five PUL projects](https://github.com/search?q=org%3Apulibrary+write_version&type=code). I don't care strongly about this -- I think it would also be ok to close this PR and the corresponding issue without merging.