### PR TITLE
Middleware/API architecture proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ coverage
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Byebug
+.byebug_history

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -2,7 +2,9 @@
 module Api
     module V0
         class ProjectsController < ApplicationController
-            def index; end
+            def index
+                render json: "{}"
+            end
         end
     end
 end

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -3,7 +3,8 @@ module Api
   module V0
     class ProjectsController < ApplicationController
       def index
-        render json: ApiMiddleware.new.projects.to_json
+        projects = ApiMiddleware.new.projects
+        render json: projects.to_json
       end
     end
   end

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 module Api
-    module V0
-        class ProjectsController < ApplicationController
-            def index
-                render json: ApiMiddleware.new().projects.to_json
-            end
-        end
+  module V0
+    class ProjectsController < ApplicationController
+      def index
+        render json: ApiMiddleware.new.projects.to_json
+      end
     end
+  end
 end
-  

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Api
+    module V0
+        class ProjectsController < ApplicationController
+            def index; end
+        end
+    end
+end
+  

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -3,7 +3,7 @@ module Api
     module V0
         class ProjectsController < ApplicationController
             def index
-                render json: ApiClient.new().projects.to_json
+                render json: ApiMiddleware.new().projects.to_json
             end
         end
     end

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -3,7 +3,7 @@ module Api
     module V0
         class ProjectsController < ApplicationController
             def index
-                render json: "{}"
+                render json: [{name: "fake project"}].to_json
             end
         end
     end

--- a/app/controllers/api/v0/projects_controller.rb
+++ b/app/controllers/api/v0/projects_controller.rb
@@ -3,7 +3,7 @@ module Api
     module V0
         class ProjectsController < ApplicationController
             def index
-                render json: [{name: "fake project"}].to_json
+                render json: ApiClient.new().projects.to_json
             end
         end
     end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 class WelcomeController < ApplicationController
-  def index; end
+  def index
+    @projects = ApiMiddleware.new.projects
+  end
 end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,5 +1,0 @@
-class ApiClient
-    def projects
-        [{name: "fake project"}]
-    end
-end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,0 +1,5 @@
+class ApiClient
+    def projects
+        [{name: "fake project"}]
+    end
+end

--- a/app/models/api_middleware.rb
+++ b/app/models/api_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApiMiddleware
   # The database and Mediaflux should only be accessed through this class.
   # Since our backend is in flux, and we're not sure what will be handled

--- a/app/models/api_middleware.rb
+++ b/app/models/api_middleware.rb
@@ -1,13 +1,13 @@
 class ApiMiddleware
-    # The database and Mediaflux should only be accessed through this class.
-    # Since our backend is in flux, and we're not sure what will be handled
-    # by the database and what by mediaflux, we do not want references to
-    # either scattered across the codebase.
-    #
-    # In turn, this class should only be referenced by api routes.
-    # All the UI pages will depend on the API. Limiting ourselves to the
-    # API will ensure that the API can do everything the UI can do.
-    def projects
-        [{name: "fake project"}]
-    end
+  # The database and Mediaflux should only be accessed through this class.
+  # Since our backend is in flux, and we're not sure what will be handled
+  # by the database and what by mediaflux, we do not want references to
+  # either scattered across the codebase.
+  #
+  # In turn, this class should only be referenced by api routes.
+  # All the UI pages will depend on the API. Limiting ourselves to the
+  # API will ensure that the API can do everything the UI can do.
+  def projects
+    [{ name: "fake project" }]
+  end
 end

--- a/app/models/api_middleware.rb
+++ b/app/models/api_middleware.rb
@@ -5,9 +5,8 @@ class ApiMiddleware
   # by the database and what by mediaflux, we do not want references to
   # either scattered across the codebase.
   #
-  # In turn, this class should only be referenced by api routes.
-  # All the UI pages will depend on the API. Limiting ourselves to the
-  # API will ensure that the API can do everything the UI can do.
+  # As the middleware grows to support the needs of the frontend,
+  # we need to be sure to add corresponding API routes.
   def projects
     [{ name: "fake project" }]
   end

--- a/app/models/api_middleware.rb
+++ b/app/models/api_middleware.rb
@@ -1,0 +1,13 @@
+class ApiMiddleware
+    # The database and Mediaflux should only be accessed through this class.
+    # Since our backend is in flux, and we're not sure what will be handled
+    # by the database and what by mediaflux, we do not want references to
+    # either scattered across the codebase.
+    #
+    # In turn, this class should only be referenced by api routes.
+    # All the UI pages will depend on the API. Limiting ourselves to the
+    # API will ensure that the API can do everything the UI can do.
+    def projects
+        [{name: "fake project"}]
+    end
+end

--- a/app/models/api_middleware.rb
+++ b/app/models/api_middleware.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 class ApiMiddleware
   # The database and Mediaflux should only be accessed through this class.
-  # Since our backend is in flux, and we're not sure what will be handled
-  # by the database and what by mediaflux, we do not want references to
-  # either scattered across the codebase.
+  # Since the respective responsibilities of the the two systems have not
+  # been determined, we want all references to both in just one place.
   #
-  # As the middleware grows to support the needs of the frontend,
+  # As the middleware grows to support the needs of the UI,
   # we need to be sure to add corresponding API routes.
   def projects
     [{ name: "fake project" }]

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,3 +1,9 @@
-Welcome to TigerData
+<h1>Welcome to TigerData</h1>
 
 <%= image_tag("logo-300-200.png", alt: "TigerData logo", size: "300x200") %>
+
+<ul>
+    <% @projects.each do |project| %>
+        <%= project[:name] %>
+    <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,8 @@ Rails.application.routes.draw do
   root to: "welcome#index"
 
   namespace :api do
-    namespace :v0 do  
+    namespace :v0 do
       resources :projects, only: [:index]
     end
   end
-  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root to: "welcome#index"
 
-  namespace :api, constraints: { format: 'json' } do
+  namespace :api do
     namespace :v0 do  
       resources :projects, only: [:index]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,11 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root to: "welcome#index"
+
+  namespace :api, constraints: { format: 'json' } do
+    namespace :v0 do  
+      resources :projects, only: [:index]
+    end
+  end
+  
 end

--- a/spec/controllers/api_v0_projects_controller_spec.rb
+++ b/spec/controllers/api_v0_projects_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Api::V0::ProjectsController do
+    render_views
+
+  it "renders the index page" do
+    get :index, params: { format: :json }
+    expect(response.body).to include("[{")
+  end
+end

--- a/spec/controllers/api_v0_projects_controller_spec.rb
+++ b/spec/controllers/api_v0_projects_controller_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V0::ProjectsController do
-    render_views
+  render_views
 
   it "renders the index page" do
     get :index, params: { format: :json }


### PR DESCRIPTION
- Fix #10

Matt has emphasized
- That everything the UI offers should also be available in the API
- That there is some kind of "Middle Layer" between the UI/API "Presentation Layer" and the "Data Management System"

This is an attempt to pin down an implementation, and I'll link to this from the agenda to make sure there can be a consensus around it. The proposal is to have an `ApiMiddleware` class that will contain all references to either the database or mediaflux:
```
  # The database and Mediaflux should only be accessed through this class.
  # Since the respective responsibilities of the the two systems have not
  # been determined, we want all references to both in just one place.
  #
  # As the middleware grows to support the needs of the UI,
  # we need to be sure to add corresponding API routes.
```

```mermaid
flowchart LR
  UI --> ApiMiddleware --> Postgres
  API --> ApiMiddleware --> Mediaflux
```

A stricter alternative would be to require that the UI use the API: This would guarantee that the UI doesn't get ahead of the API. This might make sense if we had a separate microservice for the API, but when it's all on one server, it seems gratuitous.

```mermaid
flowchart LR
  UI --> API --> ApiMiddleware --> Postgres
  ApiMiddleware --> Mediaflux
```

A looser alternative would be to let us use Rails ActiveRecord where ever we want it, and limit the middleware to just a wrapper around Mediaflux.
```mermaid
flowchart LR
  UI --> ApiMiddleware
  API --> ApiMiddleware --> Mediaflux
  UI --> Postgres
  API --> Postgres
```