### PR TITLE
Silence deprecation warnings and enable headless tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each, type: :system) do
+    if ENV["RUN_IN_BROWSER"]
+      driven_by(:selenium_chrome)
+    else
+      driven_by(:selenium_chrome_headless)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,15 +63,16 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Out of the box we get deprecation warnings from Selenium because
+  # a dependency is using :capabilities instead of :options;
+  # We configure it by hand to silence the warning,
+  # and to make sure the upgrade path is clear.
+  # Based on https://stackoverflow.com/a/70314141
   Capybara.register_driver :chrome do |app|
     options = Selenium::WebDriver::Chrome::Options.new
     options.add_argument("--headless") unless ENV["RUN_IN_BROWSER"]
 
-    Capybara::Selenium::Driver.new(
-      app,
-      browser: :chrome,
-      options: options
-    )
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 
   config.before(:each, type: :system) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,11 +63,35 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  Capybara.register_driver :headless_chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless')
+  
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: options
+    )
+  end
+  
+  Capybara.register_driver :chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+  
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: options
+    )
+  end
+  
+  Capybara.default_driver = :chrome
+
+
   config.before(:each, type: :system) do
     if ENV["RUN_IN_BROWSER"]
-      driven_by(:selenium_chrome)
+      driven_by(:chrome)
     else
-      driven_by(:selenium_chrome_headless)
+      driven_by(:headless_chrome)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,8 +73,6 @@ RSpec.configure do |config|
       options: options
     )
   end
-  
-  Capybara.default_driver = :chrome
 
   config.before(:each, type: :system) do
     driven_by(:chrome)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,8 +65,8 @@ RSpec.configure do |config|
 
   Capybara.register_driver :chrome do |app|
     options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('--headless') unless ENV["RUN_IN_BROWSER"]
-  
+    options.add_argument("--headless") unless ENV["RUN_IN_BROWSER"]
+
     Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,19 +63,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  Capybara.register_driver :headless_chrome do |app|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('--headless')
-  
-    Capybara::Selenium::Driver.new(
-      app,
-      browser: :chrome,
-      options: options
-    )
-  end
-  
   Capybara.register_driver :chrome do |app|
     options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless') unless ENV["RUN_IN_BROWSER"]
   
     Capybara::Selenium::Driver.new(
       app,
@@ -86,12 +76,7 @@ RSpec.configure do |config|
   
   Capybara.default_driver = :chrome
 
-
   config.before(:each, type: :system) do
-    if ENV["RUN_IN_BROWSER"]
-      driven_by(:chrome)
-    else
-      driven_by(:headless_chrome)
-    end
+    driven_by(:chrome)
   end
 end


### PR DESCRIPTION
- Fix #67
- Fix #48

I think the deprecation warnings are a result of a ruby library falling behind selenium: The intermediate dependency hasn't caught up, and since it's not a huge burden, we can configure it ourselves.

One other change from pdc_describe is that setting `js: true` is no longer required. My sense is that the small speedup we'd get from running without JS is not worth the possible confusion. (But I don't feel strongly, if others disagree.)