### PR TITLE
Capture screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - store_artifacts:
           path: coverage
       - store_artifacts:
-          path: /home/circleci/tiger_data/tmp/screenshots
+          path: /home/circleci/tiger_data/tmp/capybara
 
 workflows:
   version: 2

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "WelcomeController" do
   it "visits the root", js: true do
     visit "/"
 
-    expect(page).to have_content "Under Construction"
+    expect(page).to have_content "Under Construction?"
     expect(page).to have_content "Welcome to TigerData"
     click_on "Test jQuery"
     expect(page).to have_content "jQuery works!"

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "WelcomeController" do
   it "visits the root", js: true do
     visit "/"
 
-    expect(page).to have_content "Under Construction?"
+    expect(page).to have_content "Under Construction"
     expect(page).to have_content "Welcome to TigerData"
     click_on "Test jQuery"
     expect(page).to have_content "jQuery works!"


### PR DESCRIPTION
- Fix #71

On the commit that failed, I can confirm that the [artifacts page](https://app.circleci.com/pipelines/github/pulibrary/tiger-data-app/105/workflows/1ec6ffbc-570a-4df2-8308-39bd8882a7c5/jobs/369/artifacts) links to the screen shot.