### PR TITLE
[wip] Integrating docker-compose for running the Docker container environment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,10 +11,10 @@ services:
       - type: bind
         source: ./docker/files
         target: /docker-host
-    tty: true
-    stdin_open: true
-    init: true
     privileged: true
+    init: true
+    stdin_open: true
+    tty: true
 
     ## These were attempts to parse the $MFLUX_HOME env. variable before launching the JVM server
     ##
@@ -23,7 +23,17 @@ services:
     # entrypoint: bash -c "export $(grep -v '^#' /setup/scripts/convenience/mediaflux.conf | xargs) && MFLUX_HOME=/usr/local/mediaflux /usr/bin/env java -jar $MFLUX_HOME/bin/aserver.jar application.home=$MFLUX_HOME nogui"
 
     # This raises an error
-    entrypoint: bash -c "/usr/bin/env java -jar /usr/local/mediaflux/bin/aserver.jar application.home=/usr/local/mediaflux nogui"
+    entrypoint: bash -c "bash -c 'nohup /setup/scripts/convenience/arcserver start &' && tail -f /usr/local/mediaflux/volatile/logs/mediaflux-server.log"
+
+    logging: {}
+
+    healthcheck:
+      test: ["CMD", "bash -c", "'curl http://localhost:8888'"]
+      interval: 10s
+      timeout: 10s
+      start_period: 10s
+      retries: 3
 
 networks:
   mediaflux: {}
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+---
+services:
+  mediaflux:
+    image: regdev.rc.princeton.edu/developer-image:latest
+    ports:
+      - "22:22"
+      - "8888:8888"
+    networks:
+      - mediaflux
+    volumes:
+      - type: bind
+        source: ./docker/files
+        target: /docker-host
+    tty: true
+    stdin_open: true
+    init: true
+    privileged: true
+
+    ## These were attempts to parse the $MFLUX_HOME env. variable before launching the JVM server
+    ##
+    # entrypoint: bash -c 'export $(grep -v '^#' /setup/scripts/convenience/mediaflux.conf | xargs) && /usr/bin/env java -jar $MFLUX_HOME/bin/aserver.jar application.home=$MFLUX_HOME nogui'
+    # entrypoint: bash -c "export INSTALL_DIR=/usr/local/mediaflux && export $(grep -v '^#' /setup/scripts/convenience/mediaflux.conf | xargs) && /usr/bin/env java -jar $MFLUX_HOME/bin/aserver.jar application.home=$MFLUX_HOME nogui"
+    # entrypoint: bash -c "export $(grep -v '^#' /setup/scripts/convenience/mediaflux.conf | xargs) && MFLUX_HOME=/usr/local/mediaflux /usr/bin/env java -jar $MFLUX_HOME/bin/aserver.jar application.home=$MFLUX_HOME nogui"
+
+    # This raises an error
+    entrypoint: bash -c "/usr/bin/env java -jar /usr/local/mediaflux/bin/aserver.jar application.home=/usr/local/mediaflux nogui"
+
+networks:
+  mediaflux: {}


### PR DESCRIPTION
Currently, errors related to the license file are raised. In order to reproduce this, please invoke the following:

```bash
$ docker-compose up
```

One should be able to view the logs, which end with the following error:

```bash
tiger-data-app-mediaflux-1  | tail: /usr/local/mediaflux/volatile/logs/mediaflux-server.log: file truncated
tiger-data-app-mediaflux-1  | [1 main],version=4.14.014,server,22-Feb-2023 20:08:59.308:INFO:Started
tiger-data-app-mediaflux-1  | arc.mf.licence.ExInvalidLicence: The licence at file:/usr/local/mediaflux/config/licence.xml cannot be used: not a licence for this host. Expected '[ID]' but found the following ids [02:42:c0:a8:f0:02]
tiger-data-app-mediaflux-1  |   at arc.Fr.a(SourceFile:442)
tiger-data-app-mediaflux-1  |   at arc.mf.server.Server.J(SourceFile:3618)
tiger-data-app-mediaflux-1  |   at arc.mf.server.Server.a(SourceFile:680)
tiger-data-app-mediaflux-1  |   at arc.mf.server.ServerGUI.main(SourceFile:159)
```