### PR TITLE
Check users against list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem "pry-rails"
 
   gem "factory_bot_rails", require: false
+  gem "ffaker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    ffaker (2.21.0)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -391,6 +392,7 @@ DEPENDENCIES
   debug
   devise
   factory_bot_rails
+  ffaker
   importmap-rails
   jbuilder
   omniauth-cas

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,10 +5,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.nil?
       redirect_to root_path
-      flash.alert = "You are not a recognized CAS user"
+      flash.alert = "You are not a recognized CAS user."
     elsif !YAML.load_file("users.yaml").include?(@user.uid)
       redirect_to root_path
-      flash.alert = "You are not a recognized TigerData user"
+      flash.notice = "TigerData is coming soon; Access is currently limited."
     else
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
       flash.notice = "Welcome, #{@user.uid}"

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,12 +5,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.nil?
       redirect_to root_path
-      flash[:notice] = "You are not a recognized CAS user"
+      flash.alert = "You are not a recognized CAS user"
     elsif !YAML.load_file("users.yaml").include?(@user.uid)
       redirect_to root_path
-      flash[:notice] = "You are not a recognized TigerData user"
+      flash.alert = "You are not a recognized TigerData user"
     else  
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      flash.notice = "Welcome, #{@user.uid}"
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,7 +9,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     elsif !YAML.load_file("users.yaml").include?(@user.uid)
       redirect_to root_path
       flash.alert = "You are not a recognized TigerData user"
-    else  
+    else
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
       flash.notice = "Welcome, #{@user.uid}"
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,13 +5,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.nil?
       redirect_to root_path
-      flash[:notice] = "You are not authorized to view this material"
-    else
+      flash[:notice] = "You are not a recognized CAS user"
+    elsif !YAML.load_file("users.yaml").include?(@user.uid)
+      redirect_to root_path
+      flash[:notice] = "You are not a recognized TigerData user"
+    else  
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
-      if is_navigational_format?
-        set_flash_message(:notice, :success, kind: "from Princeton Central Authentication "\
-                                                  "Service")
-      end
     end
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,8 +3,5 @@ class WelcomeController < ApplicationController
   skip_before_action :authenticate_user!
   def index
     @projects = MediafluxWrapper.new.projects
-
-    flash.alert = "Under Construction!"
-    flash.notice = "Welcome to TigerData"
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,10 @@
 <header>
-  <div class="p-2 text-left bg-light">
-    <%= link_to "TigerData", root_path %>
-  </div>
+  <nav class="navbar p-2 bg-light">
+    <%= link_to "TigerData", root_path, class: "navbar-brand" %>
+    <% if current_user %>
+      <%= link_to "Log Out", main_app.destroy_user_session_path, class: "btn btn-primary btn-sm" %>
+    <% else %>
+      <%= button_to "Log In", user_cas_omniauth_authorize_path, class: "btn btn-primary btn-sm" %>
+    <% end %>
+  </nav>
 </header>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,11 +1,11 @@
-<h1>Welcome to TigerData</h1>
+<h1>TigerData</h1>
 
-<% if current_user %>
-    User: <%= current_user.uid %>
-    <%= link_to "Log Out", main_app.destroy_user_session_path, class: "btn btn-primary" %>
-<% else %>
-    <%= button_to "Log In", user_cas_omniauth_authorize_path, class: "btn btn-primary" %>
-<% end %>
+<p>
+    Welcome to the TigerData user portal.
+    <% unless current_user %>
+        Please log in.
+    <% end %>
+</p>
 
 <%= image_tag("logo-300-200.png", alt: "TigerData logo", size: "300x200") %>
 

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
   context "TigerData user" do
     it "redirects to home page with notice" do
-      allow(User).to receive(:from_cas) { FactoryBot.create(:user, uid: 'knight') }
+      allow(User).to receive(:from_cas) { FactoryBot.create(:user, uid: "knight") }
       get :cas
       expect(response).to redirect_to(root_path)
       expect(flash.notice).to eq("Welcome, knight")

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -4,21 +4,30 @@ require "rails_helper"
 RSpec.describe Users::OmniauthCallbacksController do
   before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
-  context "valid user login" do
-    it "redirects to home page with success notice" do
-      allow(User).to receive(:from_cas) { FactoryBot.create(:user) }
+  context "TigerData user" do
+    it "redirects to home page with notice" do
+      allow(User).to receive(:from_cas) { FactoryBot.create(:user, uid: 'knight') }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("Successfully authenticated from Princeton Central Authentication Service account.")
+      expect(flash.notice).to eq("Welcome, knight")
     end
   end
 
-  context "invalid user" do
-    it "redirects to home page with warning notice" do
+  context "non-TigerData user" do
+    it "redirects to home page with alert" do
+      allow(User).to receive(:from_cas) { FactoryBot.create(:user) }
+      get :cas
+      expect(response).to redirect_to(root_path)
+      expect(flash.alert).to eq("You are not a recognized TigerData user")
+    end
+  end
+
+  context "non-CAS user" do
+    it "redirects to home page with alert" do
       allow(User).to receive(:from_cas) { nil }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to eq("You are not authorized")
+      expect(flash.alert).to eq("You are not a recognized CAS user")
     end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Users::OmniauthCallbacksController do
+  before { request.env["devise.mapping"] = Devise.mappings[:user] }
+
+  context "valid user login" do
+    it "redirects to home page with success notice" do
+      allow(User).to receive(:from_cas) { FactoryBot.create(:user) }
+      get :cas
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("Successfully authenticated from Princeton Central Authentication Service account.")
+    end
+  end
+
+  context "invalid user" do
+    it "redirects to home page with warning notice" do
+      allow(User).to receive(:from_cas) { nil }
+      get :cas
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("You are not authorized")
+    end
+  end
+end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Users::OmniauthCallbacksController do
       allow(User).to receive(:from_cas) { FactoryBot.create(:user) }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash.alert).to eq("You are not a recognized TigerData user")
+      expect(flash.notice).to eq("TigerData is coming soon; Access is currently limited.")
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe Users::OmniauthCallbacksController do
       allow(User).to receive(:from_cas) { nil }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash.alert).to eq("You are not a recognized CAS user")
+      expect(flash.alert).to eq("You are not a recognized CAS user.")
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user, class: "User" do
+    uid { FFaker::InternetSE.unique.login_user_name }
+    provider { :cas }
+  end
+end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe "WelcomeController" do
       click_on "Test jQuery"
       expect(page).to have_content "jQuery works!"
     end
-
-    it "has flash messages" do
-      visit "/"
-      expect(page).to have_content "Under Construction"
-      expect(page).to have_content "Welcome to TigerData"
-    end
   end
 
   context "authenticated user" do

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "WelcomeController" do
   context "unauthenticated user" do
     it "shows the 'Log In' button" do
       visit "/"
+      expect(page).to have_content "Welcome to the TigerData user portal"
       expect(page).to have_content "Log In"
     end
 
@@ -23,7 +24,7 @@ RSpec.describe "WelcomeController" do
     end
     it "shows the 'Log Out' button" do
       visit "/"
-      expect(page).to have_content "User: pul123"
+      expect(page).not_to have_content "Please log in"
       expect(page).to have_content "Log Out"
     end
   end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "WelcomeController" do
 
   context "authenticated user" do
     let(:user) { User.new(uid: "pul123") }
-    # let(:user) { FactoryBot.create :user, uid: "pul123" }
     before do
       sign_in user
     end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "WelcomeController" do
   end
 
   context "authenticated user" do
-    let(:user) { User.new(uid: "pul123") }
+    let(:user) { FactoryBot.create(:user, uid: "pul123") }
     before do
       sign_in user
     end


### PR DESCRIPTION
- Fix #61
- Fix #21
 
... with the caveat that successful login does not redirect you to a separate dashboard page. My sense is that it's simpler for `/` to just be the dashboard once logged in, but I don't feel strongly. 