### PR TITLE
Store test results on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,11 @@ jobs:
       - run: bundle exec rake db:migrate RAILS_ENV=test
       - run:
           name: Run Rspec
-          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec
+          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec \
+                   --format progress \
+                   --format RspecJunitFormatter -o ~/rspec/rspec.xml
+      - store_test_results:
+          path: ~/rspec
       - store_artifacts:
           path: coverage
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,7 @@ jobs:
       - run: bundle exec rake db:migrate RAILS_ENV=test
       - run:
           name: Run Rspec
-          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec \
-                   --format progress \
-                   --format RspecJunitFormatter -o ~/rspec/rspec.xml
+          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
       - store_test_results:
           path: ~/rspec
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,11 @@ jobs:
       - run: bundle exec rake db:migrate RAILS_ENV=test
       - run:
           name: Run Rspec
-          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
+          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/rspec/rspec.xml
       - store_test_results:
-          path: ~/rspec
+          path: /tmp/rspec
+      - run: ls /tmp/rspec
+      - run: cat /tmp/rspec/rspec.xml
       - store_artifacts:
           path: coverage
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,6 @@ jobs:
           command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/rspec/rspec.xml
       - store_test_results:
           path: /tmp/rspec
-      - run: ls /tmp/rspec
-      - run: cat /tmp/rspec/rspec.xml
       - store_artifacts:
           path: coverage
       - store_artifacts:

--- a/Gemfile
+++ b/Gemfile
@@ -89,8 +89,8 @@ group :test do
   gem "axe-core-rspec"
   gem "capybara"
   gem "rails-controller-testing"
+  gem "rspec_junit_formatter"
   gem "selenium-webdriver"
   gem "simplecov", require: false
   gem "webdrivers"
-  gem "rspec_junit_formatter"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -92,4 +92,5 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov", require: false
   gem "webdrivers"
+  gem "rspec_junit_formatter"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,8 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.28.2)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -403,6 +405,7 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   rails-controller-testing
   rspec-rails (~> 6.0.0)
+  rspec_junit_formatter
   selenium-webdriver
   simplecov
   sprockets-rails


### PR DESCRIPTION
With this turned on, [CircleCI aggregates statistics across test runs](https://app.circleci.com/insights/github/pulibrary/tiger-data-app/workflows/build_accept_deploy/tests?branch=mccalluc-store-test-results), and identifies flaky tests and slow tests.