### PR TITLE
Simple util function for rendering schema definition XML

### DIFF
--- a/lib/xml_utilities.rb
+++ b/lib/xml_utilities.rb
@@ -1,18 +1,32 @@
+require 'yaml'
+
 # frozen_string_literal: true
 TYPENAMES = { 1 => "element", 2 => "attribute", 3 => "text", 4 => "cdata", 8 => "comment" }.freeze
 
-def xml_to_hash(document)
+def xml_node_to_hash(node)
   # Based on https://stackoverflow.com/a/10144623
-
-  node = document.root
-
-  { kind: TYPENAMES[node.node_type], name: node.name }.tap do |h|
+  {}.tap do |h|
+    h[:name] = node.name
+    node_type_name = TYPENAMES[node.node_type]
+    if node_type_name != "element"
+      h[:name] += " (#{node_type_name})"
+    end
     if node.namespace
       h[:nshref] = node.namespace.href
       h[:nsprefix] = node.namespace.prefix
     end
     h[:text] = node.text unless node.text.empty?
-    h[:attr] = node.attribute_nodes.map(&:to_hash) if node.element? && !node.attribute_nodes.empty?
-    h.merge! kids: node.children.map(&:to_hash) if node.element? && !node.children.empty?
+    h[:attr] = node.attribute_nodes.map{ |attr_node| xml_node_to_hash(attr_node) } if node.element? && !node.attribute_nodes.empty?
+    h.merge! subelements: node.children.map{ |child_node| xml_node_to_hash(child_node) } if node.element? && !node.children.empty?
   end
+end
+
+def xml_doc_to_hash(document)
+  xml_node_to_hash(document.root)
+end
+
+def xml_doc_to_html(document)
+  as_hash = xml_doc_to_hash(document)
+  as_yaml = YAML.dump(as_hash).gsub(/\A---\n/, "")
+  "<pre>#{CGI::escapeHTML(as_yaml)}</pre>"
 end

--- a/lib/xml_utilities.rb
+++ b/lib/xml_utilities.rb
@@ -6,20 +6,21 @@ TYPENAMES = { 1 => "element", 2 => "attribute", 3 => "text", 4 => "cdata", 8 => 
 
 def xml_node_to_hash(node)
   # Based on https://stackoverflow.com/a/10144623
-  {}.tap do |h|
-    h[:name] = node.name
-    node_type_name = TYPENAMES[node.node_type]
-    if node_type_name != "element"
-      h[:name] += " (#{node_type_name})"
-    end
-    if node.namespace
-      h[:nshref] = node.namespace.href
-      h[:nsprefix] = node.namespace.prefix
-    end
-    h[:text] = node.text unless node.text.empty?
-    h[:attr] = node.attribute_nodes.map { |attr_node| xml_node_to_hash(attr_node) } if node.element? && !node.attribute_nodes.empty?
-    h.merge! subelements: node.children.map { |child_node| xml_node_to_hash(child_node) } if node.element? && !node.children.empty?
+  h = {}
+  h[:name] = node.name
+  # For our needs, I think the type name clear from context.
+  # node_type_name = TYPENAMES[node.node_type]
+  # if node_type_name != "element"
+  #   h[:name] += " (#{node_type_name})"
+  # end
+  if node.namespace
+    h[:nshref] = node.namespace.href
+    h[:nsprefix] = node.namespace.prefix
   end
+  h[:text] = node.text unless node.text.empty?
+  h[:attributes] = node.attribute_nodes.map { |attr_node| xml_node_to_hash(attr_node) } if node.element? && !node.attribute_nodes.empty?
+  h[:subelements] = node.children.map { |child_node| xml_node_to_hash(child_node) } if node.element? && !node.children.empty?
+  h
 end
 
 def xml_doc_to_hash(document)

--- a/lib/xml_utilities.rb
+++ b/lib/xml_utilities.rb
@@ -1,14 +1,18 @@
-TYPENAMES = {1=>'element',2=>'attribute',3=>'text',4=>'cdata',8=>'comment'}
+# frozen_string_literal: true
+TYPENAMES = { 1 => "element", 2 => "attribute", 3 => "text", 4 => "cdata", 8 => "comment" }.freeze
 
 def xml_to_hash(document)
   # Based on https://stackoverflow.com/a/10144623
 
   node = document.root
-  
-  {kind:TYPENAMES[node.node_type],name:node.name}.tap do |h|
-    h.merge! nshref:node.namespace.href, nsprefix:node.namespace.prefix if node.namespace
-    h.merge! text:node.text
-    h.merge! attr:node.attribute_nodes.map(&:to_hash) if node.element?
-    h.merge! kids:node.children.map(&:to_hash) if node.element?
+
+  { kind: TYPENAMES[node.node_type], name: node.name }.tap do |h|
+    if node.namespace
+      h[:nshref] = node.namespace.href
+      h[:nsprefix] = node.namespace.prefix
+    end
+    h[:text] = node.text unless node.text.empty?
+    h[:attr] = node.attribute_nodes.map(&:to_hash) if node.element? && !node.attribute_nodes.empty?
+    h.merge! kids: node.children.map(&:to_hash) if node.element? && !node.children.empty?
   end
 end

--- a/lib/xml_utilities.rb
+++ b/lib/xml_utilities.rb
@@ -1,0 +1,14 @@
+TYPENAMES = {1=>'element',2=>'attribute',3=>'text',4=>'cdata',8=>'comment'}
+
+def xml_to_hash(document)
+  # Based on https://stackoverflow.com/a/10144623
+
+  node = document.root
+  
+  {kind:TYPENAMES[node.node_type],name:node.name}.tap do |h|
+    h.merge! nshref:node.namespace.href, nsprefix:node.namespace.prefix if node.namespace
+    h.merge! text:node.text
+    h.merge! attr:node.attribute_nodes.map(&:to_hash) if node.element?
+    h.merge! kids:node.children.map(&:to_hash) if node.element?
+  end
+end

--- a/lib/xml_utilities.rb
+++ b/lib/xml_utilities.rb
@@ -1,4 +1,5 @@
-require 'yaml'
+# frozen_string_literal: true
+require "yaml"
 
 # frozen_string_literal: true
 TYPENAMES = { 1 => "element", 2 => "attribute", 3 => "text", 4 => "cdata", 8 => "comment" }.freeze
@@ -16,8 +17,8 @@ def xml_node_to_hash(node)
       h[:nsprefix] = node.namespace.prefix
     end
     h[:text] = node.text unless node.text.empty?
-    h[:attr] = node.attribute_nodes.map{ |attr_node| xml_node_to_hash(attr_node) } if node.element? && !node.attribute_nodes.empty?
-    h.merge! subelements: node.children.map{ |child_node| xml_node_to_hash(child_node) } if node.element? && !node.children.empty?
+    h[:attr] = node.attribute_nodes.map { |attr_node| xml_node_to_hash(attr_node) } if node.element? && !node.attribute_nodes.empty?
+    h.merge! subelements: node.children.map { |child_node| xml_node_to_hash(child_node) } if node.element? && !node.children.empty?
   end
 end
 
@@ -28,5 +29,5 @@ end
 def xml_doc_to_html(document)
   as_hash = xml_doc_to_hash(document)
   as_yaml = YAML.dump(as_hash).gsub(/\A---\n/, "")
-  "<pre>#{CGI::escapeHTML(as_yaml)}</pre>"
+  "<pre>#{CGI.escapeHTML(as_yaml)}</pre>"
 end

--- a/spec/fixtures/doctype-to-html/single-string.xml
+++ b/spec/fixtures/doctype-to-html/single-string.xml
@@ -1,0 +1,3 @@
+<definition>
+  <element name="my_string" type="string" />
+<definition>

--- a/spec/fixtures/doctype-to-html/single-string.xml
+++ b/spec/fixtures/doctype-to-html/single-string.xml
@@ -1,3 +1,0 @@
-<definition>
-  <element name="my_string" type="string" />
-<definition>

--- a/spec/lib/xml_utilities_spec.rb
+++ b/spec/lib/xml_utilities_spec.rb
@@ -4,6 +4,14 @@ require "xml_utilities"
 
 describe "xml_utilities" do
   it "translates xml to hash" do
-    expect(xml_to_hash(Nokogiri("<a></a>"))).to eq({ kind: "element", name: "a" })
+    expect(xml_doc_to_hash(Nokogiri("<a></a>"))).to eq({ name: "a" })
+  end
+
+  it "translates xml to hash" do
+    expect(xml_doc_to_html(Nokogiri("<a></a>"))).to eq("<pre>:name: a\n</pre>")
+  end
+
+  it "translates asset type definition to hash" do
+    expect(xml_doc_to_html(Nokogiri('<definition><element name="my_string" type="string" /></definition>'))).to eq("<pre>:name: definition\n:subelements:\n- :name: element\n  :attr:\n  - :name: name (attribute)\n    :text: my_string\n  - :name: type (attribute)\n    :text: string\n</pre>")
   end
 end

--- a/spec/lib/xml_utilities_spec.rb
+++ b/spec/lib/xml_utilities_spec.rb
@@ -1,7 +1,9 @@
-require 'xml_utilities'
+# frozen_string_literal: true
+require "nokogiri"
+require "xml_utilities"
 
 describe "xml_utilities" do
-      it "translates xml to hash" do
-        expect(xml_to_hash(Nokogiri('<a></a>'))).to eq({})
-      end
-    end
+  it "translates xml to hash" do
+    expect(xml_to_hash(Nokogiri("<a></a>"))).to eq({ kind: "element", name: "a" })
+  end
+end

--- a/spec/lib/xml_utilities_spec.rb
+++ b/spec/lib/xml_utilities_spec.rb
@@ -13,15 +13,17 @@ describe "xml_utilities" do
 
   it "translates asset type definition to hash" do
     expect(xml_doc_to_html(Nokogiri('<definition><element name="my_string" type="string" /></definition>'))).to eq(
-"""<pre>:name: definition
+"<pre>:name: definition
 :subelements:
 - :name: element
-  :attr:
-  - :name: name (attribute)
+  :attributes:
+  - :name: name
     :text: my_string
-  - :name: type (attribute)
+  - :name: type
     :text: string
-</pre>"""
+</pre>"
 )
   end
+
+  # If we want more tests or longer tests, they should be checked in as fixtures.
 end

--- a/spec/lib/xml_utilities_spec.rb
+++ b/spec/lib/xml_utilities_spec.rb
@@ -12,6 +12,16 @@ describe "xml_utilities" do
   end
 
   it "translates asset type definition to hash" do
-    expect(xml_doc_to_html(Nokogiri('<definition><element name="my_string" type="string" /></definition>'))).to eq("<pre>:name: definition\n:subelements:\n- :name: element\n  :attr:\n  - :name: name (attribute)\n    :text: my_string\n  - :name: type (attribute)\n    :text: string\n</pre>")
+    expect(xml_doc_to_html(Nokogiri('<definition><element name="my_string" type="string" /></definition>'))).to eq(
+"""<pre>:name: definition
+:subelements:
+- :name: element
+  :attr:
+  - :name: name (attribute)
+    :text: my_string
+  - :name: type (attribute)
+    :text: string
+</pre>"""
+)
   end
 end

--- a/spec/lib/xml_utilities_spec.rb
+++ b/spec/lib/xml_utilities_spec.rb
@@ -1,0 +1,7 @@
+require 'xml_utilities'
+
+describe "xml_utilities" do
+      it "translates xml to hash" do
+        expect(xml_to_hash(Nokogiri('<a></a>'))).to eq({})
+      end
+    end


### PR DESCRIPTION
- Towards #58

Eventually, we'll want want to call mediaflux to list the asset types and get their definitions, but once we have the definition, we'll need to be able to show it. This is one relatively simple approach. Feedback welcome:

- Invest time now in a better rendering? (Perhaps combine attribute name values; Real html instead of pre-formatted; ...)
- Is there a better place for the code than `lib/`?