### PR TITLE
Starting point for mediaflux connectivity

### DIFF
--- a/app/models/mediaflux/collection_list.rb
+++ b/app/models/mediaflux/collection_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Mediaflux
+  class CollectionList < Connection
+    def initialize
+      super
+      response = build_request("asset.collection.list")
+      @doc = Nokogiri::XML.parse(response.body)
+    end
+
+    def to_s
+      @doc.to_s
+    end
+  end
+end

--- a/app/models/mediaflux/connection.rb
+++ b/app/models/mediaflux/connection.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module Mediaflux
+  class Connection
+    attr_reader :https, :session
+
+    def initialize
+      @https = Net::HTTP.new(Rails.configuration.mediaflux["api_host"], Rails.configuration.mediaflux["api_port"])
+      # @https.use_ssl = true
+
+      @session = login
+    end
+
+    protected
+
+      def login
+        response = build_request("system.logon") do |xml|
+          xml.args do
+            xml.domain Rails.configuration.mediaflux["api_domain"]
+            xml.user Rails.configuration.mediaflux["api_user"]
+            xml.password Rails.configuration.mediaflux["api_password"]
+          end
+        end
+        Rails.logger.debug response.body
+        doc = Nokogiri::XML.parse(response.body)
+        Rails.logger.debug doc
+        doc.xpath("response/reply/result/session").text
+      end
+
+      def build_request(name, form_file = nil)
+        args = { name: name }
+        args[:session] = session unless session.nil?
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.request do
+            xml.service(**args) do
+              yield xml if block_given?
+            end
+          end
+        end
+        send_request(builder, form_file)
+      end
+
+      def send_request(builder, form_file)
+        request = Net::HTTP::Post.new("__mflux_svc__")
+        if form_file.nil?
+          request["Content-Type"] = "text/xml; charset=utf-8"
+          request.body = builder.to_xml
+        else
+          request["Content-Type"] = "multipart/form-data"
+          request.set_form({ "request" => builder.to_xml,
+                             "nb-data-attachments" => "1",
+                             "file_0" => form_file },
+                        "multipart/form-data",
+                        "charset" => "UTF-8")
+        end
+        https.request(request)
+      end
+  end
+end

--- a/config/initializers/load_mediaflux.rb
+++ b/config/initializers/load_mediaflux.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Tigerdata
+  class Application < Rails::Application
+    config.mediaflux = config_for(:mediaflux)
+  end
+end

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -1,0 +1,25 @@
+---
+production:
+  api_port: <%= ENV["MEDIAFLUX_PORT"] %>
+  api_host: <%= ENV["MEDIAFLUX_HOST"] %>
+  api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] %>
+  api_user: <%= ENV["MEDIAFLUX_USER"] %>
+  api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
+staging:
+  api_port: <%= ENV["MEDIAFLUX_PORT"] %>
+  api_host: <%= ENV["MEDIAFLUX_HOST"] %>
+  api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] %>
+  api_user: <%= ENV["MEDIAFLUX_USER"] %>
+  api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
+development:
+  api_port: '8888'
+  api_host: '0.0.0.0'
+  api_domain: 'system'
+  api_user: 'manager'
+  api_password: 'change_me'
+test:
+  api_port: '8888'
+  api_host: '0.0.0.0'
+  api_domain: 'system'
+  api_user: 'manager'
+  api_password: 'change_me'


### PR DESCRIPTION
This does not have any tests, but it connects to you local mediaflux running in a docker container.

```
collection_list = Mediaflux::CollectionList.new
puts collection_list
```

I did not have time to advance this further, but I thought I would put a stake in the ground for where to put the new service account information.

Once the vault in [this branch](https://github.com/pulibrary/princeton_ansible/pull/3698) is updated with the password for tigerdataapp user, then you could deploy this to a server and run a rails console on the server too

Most of this code was a direct https://github.com/pulibrary/tiger-data-experiments/blob/main/simple-nokogiri/connect.rb