### PR TITLE
Moving mediaflux session into the user

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,10 +4,10 @@ class OrganizationsController < ApplicationController
   def index
     @organizations = []
     return if current_user.nil?
-    @organizations = Organization.list
+    @organizations = Organization.list(session_id: current_user.mediaflux_session)
   end
 
   def show
-    @organization = Organization.get(params[:id])
+    @organization = Organization.get(params[:id], session_id: current_user.mediaflux_session)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,8 +7,8 @@ class ProjectsController < ApplicationController
   end
 
   def new
-    organization = Organization.get(params[:organization_id].to_i)
-    @project = Project.new(-1, "", "", "", organization)
+    organization = Organization.get(params[:organization_id].to_i, session_id: current_user.mediaflux_session)
+    @project = Project.new(-1, "", "", "", organization, session_id: current_user.mediaflux_session)
     render "edit"
   end
 
@@ -22,7 +22,7 @@ class ProjectsController < ApplicationController
   def save
     name = params[:name]
     store_name = params[:store_name]
-    organization = Organization.get(params[:organization_id].to_i)
+    organization = Organization.get(params[:organization_id].to_i, session_id: current_user.mediaflux_session)
     id = params[:id].to_i
     project = if id == -1
                 # create it

--- a/app/models/mediaflux/http/logout_request.rb
+++ b/app/models/mediaflux/http/logout_request.rb
@@ -14,7 +14,7 @@ module Mediaflux
       # Specifies the Mediaflux service to use when logging off
       # @return [String]
       def self.service
-        "server.logoff"
+        "system.logoff"
       end
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,20 +10,20 @@ class Organization
     @store = nil # set on get
   end
 
-  def projects
+  def projects(session_id:)
+    Rails.logger.debug session_id # TODO: we will pass this to the project bu not now as the PR will get too big
     # TODO: memoize this value
     Project.by_organization(self)
   end
 
-  def self.get(id)
+  def self.get(id, session_id:)
     namespace = Mediaflux::Http::NamespaceDescribeRequest.new(id: id, session_token: session_id).metadata
-    end_session
     org = Organization.new(namespace[:id], namespace[:name], namespace[:path], namespace[:description])
-    org.store = Store.get_by_name(namespace[:store])
+    org.store = Store.get_by_name(namespace[:store], session_id: session_id)
     org
   end
 
-  def self.create!(name, title)
+  def self.create!(name, title, session_id:)
     id = nil
 
     namespace_fullname = Rails.configuration.mediaflux["api_root_ns"] + "/" + name
@@ -33,67 +33,52 @@ class Organization
       id = nil # TODO: get the id
     else
       Rails.logger.info "Created namespace #{namespace_fullname}"
-      namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(namespace: namespace_fullname, description: title, store: Store.all.first.name, session_token: session_id)
+      namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(namespace: namespace_fullname, description: title, store: Store.all(session_id: session_id).first.name, session_token: session_id)
       id = namespace_request.response_body
     end
 
-    end_session
     id
   end
 
-  def self.list
+  def self.list(session_id:)
     root_namespace = Rails.configuration.mediaflux["api_root_ns"]
     list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: root_namespace)
     namespace_list = list.namespaces
 
     # Horrible hack until we create a rake task to seed the server
     if namespace_list.count == 0
-      create_defaults
+      create_defaults(session_id: session_id)
       list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: root_namespace)
       namespace_list = list.namespaces
     end
 
-    organizations = namespace_list.map { |ns| Organization.get(ns[:id]) }
+    organizations = namespace_list.map { |ns| Organization.get(ns[:id], session_id: session_id) }
 
-    end_session
     organizations
   end
 
-  def self.create_root_ns
+  def self.create_root_ns(session_id:)
     root_namespace = Rails.configuration.mediaflux["api_root_ns"]
     namespace_request = Mediaflux::Http::NamespaceDescribeRequest.new(path: root_namespace, session_token: session_id)
     if namespace_request.exists?
       Rails.logger.info "Root namespace #{root_namespace} already exists"
     else
       Rails.logger.info "Created root namespace #{root_namespace}"
-      namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(namespace: root_namespace, description: "TigerData client app root namespace", store: Store.all.first.name,
+      namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(namespace: root_namespace, description: "TigerData client app root namespace",
+                                                                      store: Store.all(session_id: session_id).first.name,
                                                                       session_token: session_id)
       namespace_request.response_body
     end
-    end_session
   end
 
-  def self.create_defaults
-    create_root_ns
+  def self.create_defaults(session_id:)
+    create_root_ns(session_id: session_id)
     organizations = []
     organizations << { name: "rc", title: "Research Computing" }
     organizations << { name: "pppl", title: "Princeton Physics Plasma Lab" }
     organizations << { name: "pul", title: "Princeton University Library" }
     organizations.each do |org|
-      Organization.create!(org[:name], org[:title])
+      Organization.create!(org[:name], org[:title], session_id: session_id)
     end
-  end
-
-  def self.session_id
-    @session_id ||= begin
-                      logon_request = Mediaflux::Http::LogonRequest.new
-                      logon_request.resolve
-                      logon_request.session_token
-                    end
-  end
-
-  def self.end_session
-    Mediaflux::Http::LogoutRequest.new(session_token: session_id).response_body
-    @session_id = nil
   end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -9,22 +9,22 @@ class Store
     @tag = tag
   end
 
-  def self.all
-    # TODO: we should memoize this value
-    media_flux = MediaFluxClient.default_instance
-    data = media_flux.store_list
-    stores = data.map do |mf_store|
-      Store.new(mf_store[:id], mf_store[:type], mf_store[:name], mf_store[:tag])
+  def self.all(session_id:)
+    @all ||= begin
+      stores_request = Mediaflux::Http::StoreListRequest.new(session_token: session_id)
+      data = stores_request.stores
+      stores = data.map do |mf_store|
+        Store.new(mf_store[:id], mf_store[:type], mf_store[:name], mf_store[:tag])
+      end
+      stores
     end
-    media_flux.logout
-    stores
   end
 
-  def self.get_by_name(name)
-    all.find { |store| store.name == name }
+  def self.get_by_name(name, session_id:)
+    all(session_id: session_id).find { |store| store.name == name }
   end
 
-  def self.default
-    all.first
+  def self.default(session_id:)
+    all(session_id: session_id).first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,19 @@ class User < ApplicationRecord
     end
     user
   end
+
+  def mediaflux_session
+    @mediaflux_session ||= begin
+                            logon_request = Mediaflux::Http::LogonRequest.new
+                            logon_request.resolve
+                            logon_request.session_token
+                          end
+  end
+
+  def terminate_mediaflux_session
+    return if @mediaflux_session.nil? # nothing to terminate
+
+    Mediaflux::Http::LogoutRequest.new(session_token: @mediaflux_session).response_body
+    @mediaflux_session = nil
+  end
 end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -15,7 +15,7 @@ Store: <%= @organization.store.name %> (<%= @organization.store.type %>)</br>
       <th>File Count</th>
       <th>Store</th>
     </tr>
-    <% @organization.projects.each do |project| %>
+    <% @organization.projects(session_id: current_user.mediaflux_session).each do |project| %>
       <tr>
         <td><%= link_to(project.name, project_path(project.id)) %></td>
         <td><%= project.file_count %></td>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -4,7 +4,7 @@
   Organization: <%= @project.organization.name %> <br/>
   Name: <input type="text" id="name" name="name" required autofocus value="<%= @project.name %>" /><br/>
   Store: <input type="text" id="store_name" name="store_name" required value="<%= @project.store_name %>" />
-  (<%= Store.all.map(&:name).join(',') %>)<br/>
+  (<%= Store.all(session_id: @session_id).map(&:name).join(',') %>)<br/>
 
   --<br/>
   Internal values (don't touch them)<br/>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,10 @@ module TigerDataApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # terminate the mediaflux session if the user logs out
+    Warden::Manager.before_logout do |user, _auth, _opts|
+      user.terminate_mediaflux_session
+    end
   end
 end

--- a/spec/models/mediaflux/http/logoff_request_spec.rb
+++ b/spec/models/mediaflux/http/logoff_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mediaflux::Http::LogoutRequest, type: :model do
 
   before do
     stub_request(:post, mediflux_url)
-      .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"server.logoff\" session=\"test-session-token\"/>\n</request>\n")
+      .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"system.logoff\" session=\"test-session-token\"/>\n</request>\n")
       .to_return(status: 200, body: metdata_response, headers: {})
   end
 

--- a/spec/support/stub_mediaflux.rb
+++ b/spec/support/stub_mediaflux.rb
@@ -75,7 +75,7 @@ RSpec.configure do |config|
         ).to_return(status: 200, body: namespace_describe_response_body)
       stub_request(:post, "http://mediaflux.example.com:8888/__mflux_svc__")
         .with(
-          body: /<service name="server.logoff" session="test-session-token"\/>/
+          body: /<service name="system.logoff" session="test-session-token"\/>/
         ).to_return(status: 200, body: system_logoff_response_body)
       stub_request(:post, "http://mediaflux.example.com:8888/__mflux_svc__")
         .with(


### PR DESCRIPTION
Utilizing this session in the two converted classes Organization and Store 

Wanted to limit the scope of this PR, so I did not utilize the new mediflux_session in anything that was utilizing MedifluxClient still.  Those will be addressed in another PR 

Also fixes the bug that `server.logoff` is not the command, but `system.logoff` is.

refs #132