### PR TITLE
Adding mediaflux session information into the session cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,20 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+  around_action :mediaflux_session
 
   def new_session_path(_scope)
     new_user_session_path
   end
+
+  private
+
+    def mediaflux_session
+      current_user&.mediaflux_from_session(session)
+      yield
+    rescue Mediaflux::Http::SessionExpired
+      current_user.clear_mediaflux_session(session)
+      current_user.mediaflux_from_session(session)
+      retry
+    end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,7 +3,8 @@ class WelcomeController < ApplicationController
   skip_before_action :authenticate_user!
   def index
     return if current_user.nil?
-    @mf_version = MediaFluxClient.default_instance.version
+    version_request = Mediaflux::Http::VersionRequest.new(session_token: current_user.mediaflux_session)
+    @mf_version = version_request.version
   end
 
   # def set_note

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,19 @@ class User < ApplicationRecord
     user
   end
 
+  def clear_mediaflux_session(session)
+    @mediaflux_session = nil
+    session[:mediaflux_session] = nil
+  end
+
+  def mediaflux_from_session(session)
+    if session[:mediaflux_session].blank?
+      session[:mediaflux_session] = mediaflux_session
+    else
+      @mediaflux_session = session[:mediaflux_session]
+    end
+  end
+
   def mediaflux_session
     @mediaflux_session ||= begin
                             logon_request = Mediaflux::Http::LogonRequest.new

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,9 +1,24 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe WelcomeController, stub_mediaflux: true do
+RSpec.describe WelcomeController do
   it "renders the index page" do
     get :index
     expect(response).to render_template("index")
+    assert_not_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__")
+  end
+
+  context "when a user is logged in", stub_mediaflux: true do
+    let(:user) { FactoryBot.create :user }
+    before do
+      sign_in user
+    end
+
+    it "renders the index page" do
+      get :index
+      expect(response).to render_template("index")
+      assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+                       body: /<service name="system.logon">/)
+    end
   end
 end

--- a/spec/system/organiztions_spec.rb
+++ b/spec/system/organiztions_spec.rb
@@ -28,5 +28,8 @@ RSpec.describe "Organizations", stub_mediaflux: true do
     visit "/"
     click_on "Organizations"
     expect(page).to have_content("Princeton Physics Plasma Lab")
+    # Only login once when loading multiple pages
+    assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+                     body: /<service name="system.logon">/)
   end
 end


### PR DESCRIPTION
This keeps the login around between pages requests

Also removed the mediaflux client from the Welcome controller

refs #132