### PR TITLE
Removing extraneous call to GetMetadata for Organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -14,8 +14,8 @@ class Organization
     @projects ||= Project.by_organization(self, session_id: session_id)
   end
 
-  def self.get(id, session_id:)
-    namespace = Mediaflux::Http::NamespaceDescribeRequest.new(id: id, session_token: session_id).metadata
+  def self.get(id, session_id:, path: nil)
+    namespace = Mediaflux::Http::NamespaceDescribeRequest.new(id: id, path: path, session_token: session_id).metadata
     org = Organization.new(namespace[:id], namespace[:name], namespace[:path], namespace[:description])
     org.store = Store.get_by_name(namespace[:store], session_id: session_id)
     org

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Project, type: :model do
       expect(project.store_name).to eq("mystore")
       expect(Mediaflux::Http::GetMetadataRequest).to have_received(:new).with({ id: "id", session_token: "123abc" })
       expect(metadata_request).to have_received("metadata")
-      expect(Organization).to have_received(:get).with("1234", session_id: "123abc")
+      expect(Organization).to have_received(:get).with(nil, session_id: "123abc", path: "td-demo-001/rc")
       expect(project.id).to eq("abc")
       expect(project.name).to eq("test")
       expect(project.path).to eq("td-demo-001/rc/test-ns/test")


### PR DESCRIPTION
Organizations can be loaded via path, so no need to load the id via path and then query it again via the id