### PR TITLE
Asset Metadata and sample data

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ There is no shortage of documentation for MediaFlux, but it can be hard to know 
 
 * [Local development with Docker](local_development.md)
 * [Aterm for beginners](aterm_101.md)
+* [Sample data to initialize your local Docker](sandbox_data.md)

--- a/docs/aterm_101.md
+++ b/docs/aterm_101.md
@@ -285,24 +285,23 @@ To create a document type with specific elements you need to pass the definition
 
 * name (string)
 * sponsor (string)
-* max_gb (integer):
+* max_gb (integer)
+* created_on (date)
 
 ```
-> asset.doc.type.update :create true :description "sandbox metadata" :type sandbox_meta:project :definition < :element -name name -type string :element -name sponsor -type string :element -name max_gb -type integer >
+> asset.doc.type.update :create true :description "sandbox metadata" :type sandbox_meta:project :definition < :element -name name -type string :element -name sponsor -type string :element -name max_gb -type integer :element -name created_on -type date >
 ```
 
 Once we have defined our document type and its elements (fields) we can set the values for these fields on our assets. For example, to set the values in our `/sandbox_ns/rdss_collection` we could use the following command:
 
 ```
-> asset.set :id path=/sandbox_ns/rdss_collection :meta < :sandbox_meta:project < :name "RDSS test project" :sponsor "Library" :max_gb 100 > >
+> asset.set :id path=/sandbox_ns/rdss_collection :meta < :sandbox_meta:project < :name "RDSS test project" :sponsor "Library" :max_gb 100 :created_on "31-AUG-2023" > >
 ```
 
 and we can review this information via the `asset.get` command:
 
-
 ```
 > asset.get :id path=/sandbox_ns/rdss_collection
-
 
 :asset -id "1101" -version "3" -collection "true" -vid "1534"
         :type "content/unknown"
@@ -315,6 +314,7 @@ and we can review this information via the `asset.get` command:
                 :name "RDSS test project"
                 :sponsor "Library"
                 :max_gb "100"
+                :created_on "31-Aug-2023 00:00:00"
 ```
 
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -37,7 +37,7 @@ princeton_dev        23.08.25               311dab7822dd   3 days ago      1.35G
 ...other images...
 ```
 
-1. Now that we have the loaded the image we can _create a container_ with it (notice we name it "mediaflux")
+5. Now that we have the loaded the image we can _create a container_ with it (notice we name it "mediaflux")
 
 ```
 $ docker create --name mediaflux --publish 0.0.0.0:8888:8888 princeton_dev:23.08.25

--- a/docs/sandbox_data.md
+++ b/docs/sandbox_data.md
@@ -1,0 +1,51 @@
+# Execute this script to populate a MediaFlux server with some sample data:
+# - a metadata schema
+# - a namespace
+# - a collection asset within the namespace
+# - set the collection asset with some values for the fields defined in the metadata schema
+#
+# You can run it from within Aterm with a command as follows:
+#
+# script.execute :in file://full/path/to/tiger-data-app/docs/sandbox_data.md
+
+# ------------------------------------------------------
+# YOU CAN SET THESE VALUES TO YOUR LIKING
+# (The value used for demo_content_file should point to a file that exists on your machine
+# /etc/protocols is a good bet but adust if necessary)
+set demo_schema sandbox_meta12
+set demo_ns sandbox_ns12
+set demo_project rdss_project12
+set demo_content_file /etc/protocols
+# ------------------------------------------------------
+
+
+# Fixes the display bug in the Desktop
+actor.grant :type user :name system:manager :role -type role desktop-experimental
+
+
+# Defines a metadata namespace with one document type for "project" data
+asset.doc.namespace.create :namespace $demo_schema :description "the metadata definition for our sandbox"
+
+asset.doc.type.update :create true :description "sandbox metadata" :type $demo_schema:project :definition < :element -name name -type string :element -name sponsor -type string :element -name max_gb -type integer :element -name created_on -type date >
+
+
+# Creates namespace and collection asset inside the namespace
+asset.namespace.create :namespace /$demo_ns
+asset.create :namespace /$demo_ns :name $demo_project :collection -unique-name-index true -contained-asset-index true -cascade-contained-asset-index true true
+
+
+# Adds a new few asset to the collection asset
+asset.create :pid path=/$demo_ns/$demo_project :name file01.txt
+asset.create :pid path=/$demo_ns/$demo_project :name file02.txt
+asset.create :pid path=/$demo_ns/$demo_project :name file03.txt
+asset.create :pid path=/$demo_ns/$demo_project :name file04.txt
+
+
+# Sets the content for one of those assets
+asset.set :id path=/$demo_ns/$demo_project/file01.txt :in file:$demo_content_file
+
+
+# Sets the metadata of our demo project using the fields defined in our metadata namespace
+asset.set :id path=/$demo_ns/$demo_project :meta < :$demo_schema:project < :name "RDSS test project" :sponsor "Library" :max_gb 100 :created_on "31-AUG-2023" > >
+
+# eof

--- a/docs/sandbox_data.md
+++ b/docs/sandbox_data.md
@@ -7,6 +7,9 @@
 # You can run it from within Local Aterm (not a Web Aterm) with a command as follows:
 #
 # script.execute :in file://full/path/to/tiger-data-app/docs/sandbox_data.md
+# 
+# In the same aterm, to see the resultant collection with metadata run:
+# asset.collection.list :namespace /tigerdata_ns02 :assets true
 
 # ------------------------------------------------------
 # YOU CAN SET THESE VALUES TO YOUR LIKING

--- a/docs/sandbox_data.md
+++ b/docs/sandbox_data.md
@@ -4,7 +4,7 @@
 # - a collection asset within the namespace
 # - set the collection asset with some values for the fields defined in the metadata schema
 #
-# You can run it from within Aterm with a command as follows:
+# You can run it from within Local Aterm (not a Web Aterm) with a command as follows:
 #
 # script.execute :in file://full/path/to/tiger-data-app/docs/sandbox_data.md
 

--- a/docs/sandbox_data.md
+++ b/docs/sandbox_data.md
@@ -12,9 +12,9 @@
 # YOU CAN SET THESE VALUES TO YOUR LIKING
 # (The value used for demo_content_file should point to a file that exists on your machine
 # /etc/protocols is a good bet but adust if necessary)
-set demo_schema sandbox_meta12
-set demo_ns sandbox_ns12
-set demo_project rdss_project12
+set demo_schema tigerdata_meta02
+set demo_ns tigerdata_ns02
+set demo_project rdss_project02
 set demo_content_file /etc/protocols
 # ------------------------------------------------------
 
@@ -24,10 +24,19 @@ actor.grant :type user :name system:manager :role -type role desktop-experimenta
 
 
 # Defines a metadata namespace with one document type for "project" data
-asset.doc.namespace.create :namespace $demo_schema :description "the metadata definition for our sandbox"
+asset.doc.namespace.create :namespace $demo_schema :description "TigerData metadata schema"
 
-asset.doc.type.update :create true :description "sandbox metadata" :type $demo_schema:project :definition < :element -name name -type string :element -name sponsor -type string :element -name max_gb -type integer :element -name created_on -type date >
-
+asset.doc.type.update :create true :description "Project metadata" :type $demo_schema:project :definition < \
+    :element -name id            -type string -index true -min-occurs 1 -max-occurs 1 -label "The unique identifier for the project" \
+    :element -name title         -type string             -min-occurs 1 -max-occurs 1 -label "A plain-language title for the project" \
+    :element -name description   -type string             -min-occurs 1 -max-occurs 1 -label "A brief description of the project" \
+    :element -name data_sponsor  -type string -index true -min-occurs 1 -max-occurs 1 -label "The person who takes primary responsibility for the project" \
+    :element -name data_manager  -type string -index true -min-occurs 1 -max-occurs 1 -label "The person who manages the day-to-day activities for the project" \
+    :element -name data_users_rw -type string -index true -min-occurs 0               -label "A person who has read and write access privileges to the project" \
+    :element -name data_users_ro -type string -index true -min-occurs 0               -label "A person who has read-only access privileges to the project" \
+    :element -name departments   -type string -index true -min-occurs 1               -label "The primary Princeton University department(s) affiliated with the project" \
+    :element -name created_on    -type date               -min-occurs 1 -max-occurs 1 -label "Timestamp project was created" \
+    :element -name created_by    -type string             -min-occurs 1 -max-occurs 1 -label "User that created the project" >
 
 # Creates namespace and collection asset inside the namespace
 asset.namespace.create :namespace /$demo_ns
@@ -46,6 +55,20 @@ asset.set :id path=/$demo_ns/$demo_project/file01.txt :in file:$demo_content_fil
 
 
 # Sets the metadata of our demo project using the fields defined in our metadata namespace
-asset.set :id path=/$demo_ns/$demo_project :meta < :$demo_schema:project < :name "RDSS test project" :sponsor "Library" :max_gb 100 :created_on "31-AUG-2023" > >
+asset.set :id path=/$demo_ns/$demo_project :meta < \
+    :$demo_schema:project < \
+        :id "09az-0001" \
+        :title "Our first test project" \
+        :description "This is a test project" \
+        :data_sponsor "mjc12" \
+        :data_manager "kl37" \
+        :data_users_rw "hc8719" \
+        :data_users_rw "cac9" \
+        :data_users_ro "bs3097" \
+        :data_users_ro "jrg5" \
+        :departments "RDSS" \
+        :departments "HPC" \
+        :created_on "31-AUG-2023" \
+        :created_by "hc8719" > >
 
 # eof


### PR DESCRIPTION
Updated Asset Metadata section with an example on how to define and set a date field. 

Added file `sandbox_data.md` as an sample on how to create the schema for the project and how to use it in an asset collection. We could use this as a guide to send the right request to MediaFlux through our Ruby code. We'll do that in a separate PR.

![Screenshot 2023-08-31 at 4 42 30 PM](https://github.com/pulibrary/tiger-data-app/assets/568286/9220c69e-720f-45c9-acda-f1c7b0907a26)

