### PR TITLE
Local MediaFlux values

### DIFF
--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -16,13 +16,13 @@ staging:
   api_user: <%= ENV["MEDIAFLUX_USER"] %>
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
 development:
-  api_root_ns: <%= '/td-demo-001' %>
-  api_transport: <%= 'http' %>
-  api_host: <%= '0.0.0.0' %>
-  api_port: <%= '8888' %>
-  api_domain: <%= 'system' %>
-  api_user: <%= 'manager' %>
-  api_password: <%= 'change_me' %>
+  api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-demo-001' %>
+  api_transport: <%= ENV["MEDIAFLUX_TRANSPORT"] || 'http' %>
+  api_host: <%= ENV["MEDIAFLUX_HOST"] || '0.0.0.0' %>
+  api_port: <%= ENV["MEDIAFLUX_PORT"] || '8888' %>
+  api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] || 'system' %>
+  api_user: <%= ENV["MEDIAFLUX_USER"] || 'manager' %>
+  api_password: <%= ENV["MEDIAFLUX_PASSWORD"] || 'change_me' %>
 test:
   api_root_ns: '/td-test-001'
   api_transport: 'http'


### PR DESCRIPTION
Restore the config to allow ENV values to be used for the MediaFlux settings. I accidentally overwrote the in my last PR.