### PR TITLE
Adding a persistent connection to mediaflux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "omniauth-cas"
 gem "ddtrace", require: "ddtrace/auto_instrument"
 gem "dogstatsd-ruby"
 gem "google-protobuf", "~> 3.0"
+gem "net-http-persistent"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -205,6 +206,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.19.0)
     msgpack (1.7.2)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     net-imap (0.3.7)
       date
       net-protocol
@@ -435,6 +438,7 @@ DEPENDENCIES
   google-protobuf (~> 3.0)
   importmap-rails
   jbuilder
+  net-http-persistent
   omniauth-cas
   pg
   pry-byebug


### PR DESCRIPTION
This allows me to run the authorization test that utilizes the persistent connection without errors man many times