### PR TITLE
Adding the concept of service execute with a token to the login experiments

### DIFF
--- a/app/models/mediaflux/http/service_execute_request.rb
+++ b/app/models/mediaflux/http/service_execute_request.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class ServiceExecuteRequest < Request
+      attr_reader :token, :service_name, :document
+
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      # @param service_name  [String] Name of the service to run.
+      #                               Can be any command like asset.namespace.list
+      # @param token         [String] Optional User token for the person executing the command
+      # @param document      [String] Optional xml document to pass on to the service.
+      #                               Used to pass parameters to the command
+      def initialize(session_token:, service_name:, token: nil, document: nil)
+        super(session_token: session_token)
+        @service_name = service_name
+        @token = token
+        @document = document
+      end
+
+      # Specifies the Mediaflux service to use when creating assets
+      # @return [String]
+      def self.service
+        "service.execute"
+      end
+
+      private
+
+        def build_http_request_body(name:)
+          super do |xml|
+            xml.args do
+              xml.token token if token.present?
+              xml.service name: service_name do
+                xml << document
+              end
+            end
+          end
+        end
+    end
+  end
+end

--- a/spec/models/mediaflux/http/service_execute_request_spec.rb
+++ b/spec/models/mediaflux/http/service_execute_request_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::Http::ServiceExecuteRequest, type: :model do
+  subject(:request) { described_class.new(session_token: session_token, service_name: "asset.namespace.list") }
+
+  let(:session_token) { "test-session-token" }
+  let(:identity_token) { "test-identity-token" }
+  let(:response_body) do
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <reply type="result">
+    <result>
+      <uuid>4892</uuid>
+      <reply service="asset.namespace.list">
+        <response>
+          <namespace path="/">
+            <namespace id="1080" leaf="true" acl="false">Princeton</namespace>
+            <namespace id="4" leaf="false" acl="false" restricted-visibility="true">mflux</namespace>
+            <namespace id="6" leaf="false" acl="false" restricted-visibility="true">system</namespace>
+            <namespace id="8" leaf="false" acl="false" restricted-visibility="true">www</namespace>
+          </namespace>
+        </response>
+      </reply>
+    </result>
+  </reply>
+</response>
+    XML
+  end
+
+  let(:mediflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+
+  before do
+    stub_request(:post, mediflux_url).to_return(status: 200, body: response_body)
+  end
+
+  describe "#resolve" do
+    it "sends the service execute" do
+      request.resolve
+      assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+                       body: /service name="service.execute".*<service name="asset.namespace.list"\/>.*/m)
+    end
+
+    context "when a document is passed" do
+      subject(:request) { described_class.new(session_token: session_token, service_name: "asset.namespace.list", document: "<id>1</id>") }
+
+      it "sends the service execute" do
+        request.resolve
+        assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+                         body: /service name="service.execute".*<service name="asset.namespace.list">.*<id>1<\/id>.*<\/service>.*/m)
+      end
+    end
+
+    context "when a token is passed" do
+      subject(:request) { described_class.new(session_token: session_token, service_name: "asset.namespace.list", token: "tokentoken") }
+
+      it "sends the service execute" do
+        request.resolve
+        assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+                         body: /service name="service.execute".*<token>tokentoken<\/token>.*<service name="asset.namespace.list"\/>.*/m)
+      end
+    end
+  end
+end


### PR DESCRIPTION

Adds the Service Execute request to our arsenal of mediaflux commands