### PR TITLE
Remove Mediaflux dependency when a user logs in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-22
   x86_64-linux

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   private
 
     def mediaflux_session
-      # this requires a connection to mediaflux
+      # this requires a connection to mediaflux... for ease of development we do not want to require this
       # current_user&.mediaflux_from_session(session)
       yield
     rescue Mediaflux::Http::SessionExpired

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
   private
 
     def mediaflux_session
-      current_user&.mediaflux_from_session(session)
+      # this requires a connection to mediaflux
+      # current_user&.mediaflux_from_session(session)
       yield
     rescue Mediaflux::Http::SessionExpired
       current_user.clear_mediaflux_session(session)

--- a/lib/tasks/roles.rake
+++ b/lib/tasks/roles.rake
@@ -2,10 +2,10 @@
 namespace :roles do
   desc "Create or update the system users for the project sponsor role"
   task default_sponsors: :environment do
-    config.default_sponsors.each do |sponsor|
+    Rails.application.config.default_sponsors.each do |sponsor|
       user = User.find_by(uid: sponsor)
       if user.nil?
-        user = User.create(uid: sponsor, provider: "cas", emai: "#{sponsor}@princeton.edu")
+        user = User.create(uid: sponsor, provider: "cas", email: "#{sponsor}@princeton.edu")
       end
       unless user.has_role? User::PROJECT_SPONSOR
         user.add_role User::PROJECT_SPONSOR

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe WelcomeController do
     it "renders the index page" do
       get :index
       expect(response).to render_template("index")
-      assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
-                       body: /<service name="system.logon">/)
+      # this requires a connection to mediaflux... for ease of development we do not want to require this
+      # assert_requested(:post, "http://mediaflux.example.com:8888/__mflux_svc__",
+      #                  body: /<service name="system.logon">/)
     end
   end
 end


### PR DESCRIPTION
Also fix bugs in rake task roles:default_sponsors

Co-authored-by: Claudia Lee <claudiawulee@users.noreply.github.com>

