### PR TITLE
Creating lots of projects to benchmark performance

### DIFF
--- a/app/models/mediaflux/http/collection_count_request.rb
+++ b/app/models/mediaflux/http/collection_count_request.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class CollectionCountRequest < Request
+
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      # @param namespace [String] Namespace to limit the search
+      # @param data_sponsor [String] Datasponsor for the collection
+      # @param data_sponsor [String] Department assigned to the collection
+      def initialize(session_token:, namespace:, data_sponsor: nil, department: nil)
+        super(session_token: session_token)
+        @namespace = namespace
+        @data_sponsor = data_sponsor
+        @department = department
+      end
+
+      # Specifies the Mediaflux service to use
+      # @return [String]
+      def self.service
+        "asset.count"
+      end
+
+      def count
+        @count ||= response_xml.xpath("/response/reply/result/total").text
+        @count
+      end
+
+      private
+
+        def build_http_request_body(name:)
+          super(name: name) do |xml|
+            xml.args do
+              xml.namespace @namespace
+              xml.where build_where_clause
+            end
+          end
+        end
+
+        def build_where_clause
+          where_clause = "asset is collection"
+          if @data_sponsor
+            where_clause += " AND tigerdata:project/data_sponsor='#{@data_sponsor}'"
+          end
+          if @department
+            where_clause += " AND tigerdata:project/departments='#{@department}'"
+          end
+          where_clause
+        end
+    end
+  end
+end

--- a/app/models/mediaflux/http/collection_count_request.rb
+++ b/app/models/mediaflux/http/collection_count_request.rb
@@ -2,7 +2,6 @@
 module Mediaflux
   module Http
     class CollectionCountRequest < Request
-
       # Constructor
       # @param session_token [String] the API token for the authenticated session
       # @param namespace [String] Namespace to limit the search

--- a/app/models/mediaflux/http/create_asset_request.rb
+++ b/app/models/mediaflux/http/create_asset_request.rb
@@ -49,8 +49,7 @@ module Mediaflux
               xml.namespace namespace if namespace.present?
               if @tigerdata_values
                 xml.meta do
-                  # TODO:
-                  # The parameters to xml.send() need to be adjusted as indicated on
+                  # TODO: The parameters to xml.send() need to be adjusted as indicated on
                   # GitHub issue https://github.com/pulibrary/tiger-data-app/issues/227
                   #
                   # The values we are passing right here produce the correct XML

--- a/app/models/mediaflux/http/create_asset_request.rb
+++ b/app/models/mediaflux/http/create_asset_request.rb
@@ -49,7 +49,16 @@ module Mediaflux
               xml.namespace namespace if namespace.present?
               if @tigerdata_values
                 xml.meta do
-                  xml.send("tigerdata:project", "xmlns:tigerdata" => "tigerdata") do
+                  # TODO:
+                  # The parameters to xml.send() need to be adjusted as indicated on
+                  # GitHub issue https://github.com/pulibrary/tiger-data-app/issues/227
+                  #
+                  # The values we are passing right here produce the correct XML
+                  # structure but the wrong xmlns value, which we manually adjust
+                  # in request.rb
+                  #
+                  # See also https://nokogiri.org/rdoc/Nokogiri/XML/Builder.html
+                  xml.send("tigerdata:project", "xmlns" => "tigerdata:project") do
                     xml.code @tigerdata_values[:code]
                     xml.title @tigerdata_values[:title]
                     xml.description @tigerdata_values[:description]

--- a/app/models/mediaflux/http/request.rb
+++ b/app/models/mediaflux/http/request.rb
@@ -138,6 +138,7 @@ module Mediaflux
           end
         end
 
+        # rubocop:disable Metrics/MethodLength
         def build_http_request(name:, form_file: nil)
           request = self.class.build_post_request
           body = build_http_request_body(name: name)
@@ -166,6 +167,7 @@ module Mediaflux
 
           request
         end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/models/mediaflux/http/update_asset_request.rb
+++ b/app/models/mediaflux/http/update_asset_request.rb
@@ -38,7 +38,16 @@ module Mediaflux
               xml.id @id
               if @tigerdata_values
                 xml.meta do
-                  xml.send("tigerdata:project", "xmlns:tigerdata" => "tigerdata") do
+                  # TODO:
+                  # The parameters to xml.send() need to be adjusted as indicated on
+                  # GitHub issue https://github.com/pulibrary/tiger-data-app/issues/227
+                  #
+                  # The values we are passing right here produce the correct XML
+                  # structure but the wrong xmlns value, which we manually adjust
+                  # in request.rb
+                  #
+                  # See also https://nokogiri.org/rdoc/Nokogiri/XML/Builder.html
+                  xml.send("tigerdata:project", "xmlns" => "tigerdata:project") do
                     xml.code @tigerdata_values[:code]
                     xml.title @tigerdata_values[:title]
                     xml.description @tigerdata_values[:description]

--- a/app/models/mediaflux/http/update_asset_request.rb
+++ b/app/models/mediaflux/http/update_asset_request.rb
@@ -38,8 +38,7 @@ module Mediaflux
               xml.id @id
               if @tigerdata_values
                 xml.meta do
-                  # TODO:
-                  # The parameters to xml.send() need to be adjusted as indicated on
+                  # TODO: The parameters to xml.send() need to be adjusted as indicated on
                   # GitHub issue https://github.com/pulibrary/tiger-data-app/issues/227
                   #
                   # The values we are passing right here produce the correct XML

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -71,12 +71,5 @@ class Organization
 
   def self.create_defaults(session_id:)
     create_root_ns(session_id: session_id)
-    organizations = []
-    organizations << { name: "rc", title: "Research Computing" }
-    organizations << { name: "pppl", title: "Princeton Physics Plasma Lab" }
-    organizations << { name: "pul", title: "Princeton University Library" }
-    organizations.each do |org|
-      Organization.create!(org[:name], org[:title], session_id: session_id)
-    end
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -9,6 +9,7 @@ namespace :projects do
 
     user = User.first
     Organization.create_defaults(session_id: user.mediaflux_session)
+    root_ns = Rails.configuration.mediaflux["api_root_ns"]
 
     time_action("Creating projects") do
       puts "Creating #{count} projects with prefix #{project_prefix}..."
@@ -20,7 +21,7 @@ namespace :projects do
       end
     end
 
-    query_test_projects(user)
+    query_test_projects(user, root_ns)
   end
 
   task :query, [:data_sponsor, :department] => [:environment] do |_, args|
@@ -73,11 +74,11 @@ namespace :projects do
   # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
-  def query_test_projects(user)
+  def query_test_projects(user, root_ns)
     counts = []
     ["zz001", "zz003", "zz007", nil].each do |data_sponsor|
       time_action("Getting counts by data_sponsor #{data_sponsor}") do
-        count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor)
+        count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: root_ns, data_sponsor: data_sponsor)
         count_request.resolve
         counts << { data_sponsor: data_sponsor || "total", count: count_request.count }
       end
@@ -86,7 +87,7 @@ namespace :projects do
 
     total73 = 0
     time_action("Getting counts by data_sponsor zz007 department THREE") do
-      count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: "zz007", department: "THREE")
+      count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: root_ns, data_sponsor: "zz007", department: "THREE")
       count_request.resolve
       total73 = count_request.count
     end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -5,7 +5,6 @@ namespace :projects do
     raise "Count must be specified" if count.blank?
     count = args[:count].to_i
     project_prefix = args[:prefix]
-    raise "Count must be specified" if count == 0
     raise "Project prefix must be specified" if project_prefix.nil?
 
     user = User.first

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+namespace :projects do
+  desc "Create many test projects"
+  task create_many: :environment do
+    (1..100).each do |i|
+      sequence = i.to_s.rjust(5, "0")
+      user = User.first
+
+      project = Project.new
+      project.created_by_user = user
+      project.metadata = {
+        data_sponsor: "xx123",
+        data_manager: "yy123",
+        departments: ["PUL", "RDSS"],
+        directory: "project-#{sequence}",
+        title: "Project #{sequence}",
+        description: "Description of project #{sequence}",
+        data_user_read_only: [],
+        data_user_read_write: []
+      }
+      project.save!
+
+      project.approve!(session_id: user.mediaflux_session, created_by: user.uid)
+    end
+  end
+end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -26,12 +26,14 @@ namespace :projects do
   task :query, [:data_sponsor, :department] => [:environment] do |_, args|
     data_sponsor = args[:data_sponsor]
     department = args[:department]
+    root_ns = Rails.configuration.mediaflux["api_root_ns"]
+
     user = User.first
     Organization.create_defaults(session_id: user.mediaflux_session)
 
     time_action("Getting counts by data_sponsor #{data_sponsor} department #{department} took") do
       count_request = Mediaflux::Http::CollectionCountRequest.new(
-        session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor, department: department
+        session_token: user.mediaflux_session, namespace: root_ns, data_sponsor: data_sponsor, department: department
       )
       count_request.resolve
       puts "#{count_request.count} records for #{data_sponsor} department #{department}"

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -2,7 +2,8 @@
 namespace :projects do
   desc "Times the creation of projects and querying by TigerData metadata fields"
   task :create_many, [:count, :prefix] => [:environment] do |_, args|
-    count = (args[:count] || "").to_i
+    raise "Count must be specified" if count.blank?
+    count = args[:count].to_i
     project_prefix = args[:prefix]
     raise "Count must be specified" if count == 0
     raise "Project prefix must be specified" if project_prefix.nil?

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -1,26 +1,81 @@
 # frozen_string_literal: true
 namespace :projects do
-  desc "Create many test projects"
-  task create_many: :environment do
-    (1..100).each do |i|
-      sequence = i.to_s.rjust(5, "0")
-      user = User.first
+  desc "Times the creation of projects and querying by TigerData metadata fields"
+  task :create_many, [:count, :prefix] => [:environment] do |_, args|
+    count = (args[:count] || "").to_i
+    project_prefix = args[:prefix]
+    raise "Count must be specified" if count == 0
+    raise "Project prefix must be specified" if project_prefix.nil?
 
-      project = Project.new
-      project.created_by_user = user
-      project.metadata = {
-        data_sponsor: "xx123",
-        data_manager: "yy123",
-        departments: ["PUL", "RDSS"],
-        directory: "project-#{sequence}",
-        title: "Project #{sequence}",
-        description: "Description of project #{sequence}",
-        data_user_read_only: [],
-        data_user_read_write: []
-      }
-      project.save!
+    user = User.first
+    Organization.create_defaults(session_id: user.mediaflux_session)
 
-      project.approve!(session_id: user.mediaflux_session, created_by: user.uid)
+    time_action("Creating projects") do
+      puts "Creating #{count} projects with prefix #{project_prefix}..."
+      (1..count).each do |i|
+        project = create_test_project(i, user, project_prefix)
+        project.save!
+        project.approve!(session_id: user.mediaflux_session, created_by: user.uid)
+        puts "#{i}" if (i % 100) == 0
+      end
     end
+
+    counts = []
+    ["zz001", "zz003", "zz007", nil].each do |data_sponsor|
+      time_action("Getting counts by data_sponsor #{data_sponsor}") do
+        count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor)
+        count_request.resolve
+        counts << {data_sponsor: data_sponsor || 'total', count: count_request.count}
+      end
+    end
+    puts counts
+
+    total73 = 0
+    time_action("Getting counts by data_sponsor zz007 department THREE") do
+      count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: "zz007", department: "THREE")
+      count_request.resolve
+      total73 = count_request.count
+    end
+    puts "#{total73} records for data_sponsor zz007 department THREE"
+  end
+
+  def create_test_project(number, user, project_prefix)
+    sequence = number.to_s.rjust(5, "0")
+    sponsor = if (number % 7) == 0
+                "zz007"
+              elsif (number %3) == 0
+                "zz003"
+              else
+                "zz001"
+              end
+    departments = []
+    departments << "SEVEN" if (number % 7) == 0
+    departments << "THREE" if (number % 3) == 0
+    departments << "FIVE" if (number % 5) == 0
+    departments << "ONE" if departments.count == 0
+
+    project = Project.new
+    project.created_by_user = user
+    project.metadata = {
+      data_sponsor: sponsor,
+      data_manager: "zz789",
+      departments: departments,
+      directory: "#{project_prefix}-#{sequence}",
+      title: "Project #{project_prefix} #{sequence}",
+      description: "Description of project #{project_prefix} #{sequence}",
+      data_user_read_only: [],
+      data_user_read_write: []
+    }
+    project
+  end
+
+  def time_action(label)
+    start_time = DateTime.now
+    yield
+    end_time = DateTime.now
+    sec = end_time.to_f - start_time.to_f
+    ms_display = '%.2f' % (sec * 100)
+    sec_display = '%.2f' % sec
+    puts "#{label} #{ms_display} ms #{sec_display} seconds"
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -23,10 +23,19 @@ namespace :projects do
     query_test_projects(user)
   end
 
-  task :query => [:environment] do |_, args|
+  task :query, [:data_sponsor, :department] => [:environment] do |_, args|
+    data_sponsor = args[:data_sponsor]
+    department = args[:department]
     user = User.first
     Organization.create_defaults(session_id: user.mediaflux_session)
-    query_test_projects(user)
+
+    time_action("Getting counts by data_sponsor #{data_sponsor} department #{department} took") do
+      count_request = Mediaflux::Http::CollectionCountRequest.new(
+        session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor, department: department
+      )
+      count_request.resolve
+      puts "#{count_request.count} records for #{data_sponsor} department #{department}"
+    end
   end
 
   def create_test_project(number, user, project_prefix)

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -16,7 +16,7 @@ namespace :projects do
         project = create_test_project(i, user, project_prefix)
         project.save!
         project.approve!(session_id: user.mediaflux_session, created_by: user.uid)
-        puts "#{i}" if (i % 100) == 0
+        puts i if (i % 100) == 0
       end
     end
 
@@ -38,11 +38,12 @@ namespace :projects do
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def create_test_project(number, user, project_prefix)
     sequence = number.to_s.rjust(5, "0")
     sponsor = if (number % 7) == 0
                 "zz007"
-              elsif (number %3) == 0
+              elsif (number % 3) == 0
                 "zz003"
               else
                 "zz001"
@@ -67,14 +68,16 @@ namespace :projects do
     }
     project
   end
+  # rubocop:enable Metrics/MethodLength
 
+  # rubocop:disable Metrics/MethodLength
   def query_test_projects(user)
     counts = []
     ["zz001", "zz003", "zz007", nil].each do |data_sponsor|
       time_action("Getting counts by data_sponsor #{data_sponsor}") do
         count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor)
         count_request.resolve
-        counts << {data_sponsor: data_sponsor || 'total', count: count_request.count}
+        counts << { data_sponsor: data_sponsor || "total", count: count_request.count }
       end
     end
     puts counts
@@ -87,14 +90,15 @@ namespace :projects do
     end
     puts "#{total73} records for data_sponsor zz007 department THREE"
   end
+  # rubocop:enable Metrics/MethodLength
 
   def time_action(label)
     start_time = DateTime.now
     yield
     end_time = DateTime.now
     sec = end_time.to_f - start_time.to_f
-    ms_display = '%.2f' % (sec * 100)
-    sec_display = '%.2f' % sec
+    ms_display = format("%.2f", sec * 100)
+    sec_display = format("%.2f", sec)
     puts "#{label} #{ms_display} ms #{sec_display} seconds"
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -100,7 +100,7 @@ namespace :projects do
     yield
     end_time = DateTime.now
     sec = end_time.to_f - start_time.to_f
-    ms_display = format("%.2f", sec * 100)
+    ms_display = format("%.2f", sec * 1000)
     sec_display = format("%.2f", sec)
     puts "#{label} #{ms_display} ms #{sec_display} seconds"
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -20,23 +20,13 @@ namespace :projects do
       end
     end
 
-    counts = []
-    ["zz001", "zz003", "zz007", nil].each do |data_sponsor|
-      time_action("Getting counts by data_sponsor #{data_sponsor}") do
-        count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor)
-        count_request.resolve
-        counts << {data_sponsor: data_sponsor || 'total', count: count_request.count}
-      end
-    end
-    puts counts
+    query_test_projects(user)
+  end
 
-    total73 = 0
-    time_action("Getting counts by data_sponsor zz007 department THREE") do
-      count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: "zz007", department: "THREE")
-      count_request.resolve
-      total73 = count_request.count
-    end
-    puts "#{total73} records for data_sponsor zz007 department THREE"
+  task :query => [:environment] do |_, args|
+    user = User.first
+    Organization.create_defaults(session_id: user.mediaflux_session)
+    query_test_projects(user)
   end
 
   def create_test_project(number, user, project_prefix)
@@ -67,6 +57,26 @@ namespace :projects do
       data_user_read_write: []
     }
     project
+  end
+
+  def query_test_projects(user)
+    counts = []
+    ["zz001", "zz003", "zz007", nil].each do |data_sponsor|
+      time_action("Getting counts by data_sponsor #{data_sponsor}") do
+        count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: data_sponsor)
+        count_request.resolve
+        counts << {data_sponsor: data_sponsor || 'total', count: count_request.count}
+      end
+    end
+    puts counts
+
+    total73 = 0
+    time_action("Getting counts by data_sponsor zz007 department THREE") do
+      count_request = Mediaflux::Http::CollectionCountRequest.new(session_token: user.mediaflux_session, namespace: "/td-demo-001", data_sponsor: "zz007", department: "THREE")
+      count_request.resolve
+      total73 = count_request.count
+    end
+    puts "#{total73} records for data_sponsor zz007 department THREE"
   end
 
   def time_action(label)

--- a/spec/fixtures/files/asset_update_request.xml
+++ b/spec/fixtures/files/asset_update_request.xml
@@ -5,13 +5,13 @@
       <id>1234</id>
       <meta>
         <tigerdata:project xmlns:tigerdata="tigerdata">
-          <tigerdata:code>code</tigerdata:code>
-          <tigerdata:title>title</tigerdata:title>
-          <tigerdata:description>description</tigerdata:description>
-          <tigerdata:data_sponsor>data_sponsor</tigerdata:data_sponsor>
-          <tigerdata:data_manager>data_manager</tigerdata:data_manager>
-          <tigerdata:departments>RDSS</tigerdata:departments>
-          <tigerdata:departments>HPC</tigerdata:departments>
+          <code>code</code>
+          <title>title</title>
+          <description>description</description>
+          <data_sponsor>data_sponsor</data_sponsor>
+          <data_manager>data_manager</data_manager>
+          <departments>RDSS</departments>
+          <departments>HPC</departments>
         </tigerdata:project>
       </meta>
     </args>


### PR DESCRIPTION
Adding rake tasks to create a bunch of projects (namespaces + collections) in MediaFlux and validate how well it works on each case.

The rake task can be run as:

```
bundle exec rake projects:create_many[100,test-a]
```

By default it will create the projects under the default root namespace `td-demo-001`. If you want to use a different default root you can specify it via the ENV variable:

```
MEDIAFLUX_ROOT_NS=/td-demo-06 bundle exec rake projects:create_many[100,test-a]
```

You can also run queries against MediaFlux after the projects have been created to see the timings with different parameters:

```
bundle exec rake projects:query[zz007,THREE]
```

See https://github.com/pulibrary/tiger-data-app/issues/224#issuecomment-1781792431 for the results in stating.
