### PR TITLE
Remove hardcoded root namespace from a few extra places

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,18 +4,18 @@
   <h2>Roles</h2>
   <p>Data Sponsor: <%= @project.metadata[:data_sponsor] %></p>
   <p>Data Manager: <%= @project.metadata[:data_manager] %></p>
-  
+
   <%if @project.metadata[:data_user_read_only] %>
-  <p>Read Only: 
-    <% @project.metadata[:data_user_read_only].each do |user|%> 
+  <p>Read Only:
+    <% @project.metadata[:data_user_read_only].each do |user|%>
       <p><%= user%> </p>
     <%end%>
     </p>
   <%end%>
 
   <%if @project.metadata[:data_user_read_write] %>
-  <p>Read/write: 
-    <% @project.metadata[:data_user_read_write].each do |user|%> 
+  <p>Read/write:
+    <% @project.metadata[:data_user_read_write].each do |user|%>
       <p><%= user%> </p>
     <%end%>
     </p>
@@ -25,7 +25,7 @@
 <div>
   <h2>Project Description</h2>
   <p>Affiliated Departments: <%= @project.departments.join(", ") %></p>
-  <p>Project Directory: /tigerdata/<%= @project.metadata[:directory] %></p>
+  <p>Project Directory: <%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:directory] %></p>
   <p>Title: <%= @project.metadata[:title] %></p>
   <p>Description:<br/>
     <%= @project.metadata[:description] %>

--- a/app/views/tigerdata_mailer/project_creation.html.erb
+++ b/app/views/tigerdata_mailer/project_creation.html.erb
@@ -2,24 +2,23 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
-  <style> 
-        dt { 
-            font-weight: bold; 
-        } 
-  
-        dt::after { 
-            content: ":"; 
-        } 
-    </style> 
+  <style>
+    dt {
+      font-weight: bold;
+    }
+
+    dt::after {
+      content: ":";
+    }
+  </style>
   <body>
     <h1>Tigerdata Proect Request</h1>
 
     <section>
-       <p> A Project was requested by <%= @project.created_by_user.display_name %> (<%= @project.created_by_user.uid %>) 
-           <a href="mailto:<%= @project.created_by_user.email %>"><%= @project.created_by_user.email %></a>
-       </p> 
-       
-        <p>
+      <p>A Project was requested by <%= @project.created_by_user.display_name %> (<%= @project.created_by_user.uid %>)
+        <a href="mailto:<%= @project.created_by_user.email %>"><%= @project.created_by_user.email %></a>
+      </p>
+      <p>
         <dl>
           <dt>Data Sponsor</dt>
           <dd><%= @project.metadata[:data_sponsor] %></dd>
@@ -28,7 +27,7 @@
           <dt>Affiliated Departments</dt>
           <dd><%= @project.departments.join(", ") %></dd>
           <dt>Project Directory</dt>
-          <dd>/tigerdata/<%= @project.metadata[:directory] %> </dd>
+          <dd><%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:directory] %> </dd>
           <dt>Title</dt>
           <dd><%= @project.metadata[:title] %></dd>
           <dt>Description</dt>

--- a/app/views/tigerdata_mailer/project_creation.html.txt
+++ b/app/views/tigerdata_mailer/project_creation.html.txt
@@ -4,6 +4,6 @@ Requesting User Name: <%= @project.created_by_user.display_name %>
 Data Sponsor: <%= @project.metadata[:data_sponsor] %>
 Data Manager: <%= @project.metadata[:data_manager] %>
 Affiliated Departments: <%= @project.departments.join(", ") %>
-Project Directory: /tigerdata/<%= @project.metadata[:directory] %>
+Project Directory: <%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:directory] %>
 Title: <%= @project.metadata[:title] %>
 Description: <%= @project.metadata[:description] %>

--- a/spec/fixtures/files/asset_get_response.xml
+++ b/spec/fixtures/files/asset_get_response.xml
@@ -4,9 +4,9 @@
     <result>
       <asset id="1065" version="1" vid="1515">
         <type>content/unknown</type>
-        <namespace id="1099">/tigerdata/td-demo-001</namespace>
+        <namespace id="1099">/td-test-001</namespace>
         <parent>1053</parent>
-        <path>/tigerdata/td-demo-001/collection-96-55948/file-96-57045</path>
+        <path>/td-test-001/collection-96-55948/file-96-57045</path>
         <name>file-96-57045</name>
         <creator id="15">
           <domain>system</domain>

--- a/spec/fixtures/files/collection_asset_get_response.xml
+++ b/spec/fixtures/files/collection_asset_get_response.xml
@@ -4,8 +4,8 @@
     <result>
       <asset id="1065" version="1" collection="true" vid="1516">
         <type>application/arc-asset-collection</type>
-        <namespace id="1099">/tigerdata/td-demo-001</namespace>
-        <path>/tigerdata/td-demo-001/collection-96-58278</path>
+        <namespace id="1099">/td-test-001</namespace>
+        <path>/td-test-001/collection-96-58278</path>
         <name>collection-96-58278</name>
         <creator id="15">
           <domain>system</domain>

--- a/spec/models/mediaflux/http/get_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/get_metadata_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
       expect(metadata[:creator]).to eq("manager")
       expect(metadata[:description]).to eq("")
       expect(metadata[:collection]).to be_falsey
-      expect(metadata[:path]).to eq("/tigerdata/td-demo-001/collection-96-55948/file-96-57045")
+      expect(metadata[:path]).to eq("/td-test-001/collection-96-55948/file-96-57045")
       expect(metadata[:type]).to eq("content/unknown")
       expect(metadata[:size]).to eq("")
       expect(metadata[:size_human]).to eq("")
@@ -42,7 +42,7 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
         expect(metadata[:creator]).to eq("manager")
         expect(metadata[:description]).to eq("")
         expect(metadata[:collection]).to be_truthy
-        expect(metadata[:path]).to eq("/tigerdata/td-demo-001/collection-96-58278")
+        expect(metadata[:path]).to eq("/td-test-001/collection-96-58278")
         expect(metadata[:type]).to eq("application/arc-asset-collection")
         expect(metadata[:size]).to eq("")
         expect(metadata[:size_human]).to eq("")

--- a/spec/models/mediaflux/http/query_request_spec.rb
+++ b/spec/models/mediaflux/http/query_request_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Mediaflux::Http::QueryRequest, type: :model do
     before do
       stub_request(:post, mediflux_url)
         .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.query\" session=\"secretsecret/2/31\">\n    "\
-                    "<args>\n      <where>namespace='/tigerdata/td-demo-001'</where>\n      <idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
+                    "<args>\n      <where>namespace='/td-test-001'</where>\n      <idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
         .to_return(status: 200, body: query_response, headers: {})
     end
 
     it "returns a cursor" do
-      query_request = described_class.new(session_token: "secretsecret/2/31", aql_query: "namespace='/tigerdata/td-demo-001'")
+      query_request = described_class.new(session_token: "secretsecret/2/31", aql_query: "namespace='/td-test-001'")
       result = query_request.result
       expect(result[:ids]).to eq(["1057", "1058", "1059", "1060", "1061", "1062", "1063", "1064", "1065", "1066"])
       expect(result[:size]).to eq(0)


### PR DESCRIPTION
Turns out the `/tigerdata/` root namespace was hard-coded in more places than we thought.

Closes #229 for real


