### PR TITLE
Ensuring the asset creation XML payloads for POST requests does not remove `tigerdata` XML namespaces

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,7 +20,8 @@ class ProjectsController < ApplicationController
 
   def approve
     @project = Project.find(params[:id])
-    @project.approve!(session_id: current_user.mediaflux_session, created_by: current_user.uid)
+    xml_namespace = params[:xml_namespace]
+    @project.approve!(session_id: current_user.mediaflux_session, created_by: current_user.uid, xml_namespace: xml_namespace)
     redirect_to @project
   end
 

--- a/app/models/mediaflux/http/create_asset_request.rb
+++ b/app/models/mediaflux/http/create_asset_request.rb
@@ -4,6 +4,13 @@ module Mediaflux
     class CreateAssetRequest < Request
       attr_reader :namespace, :asset_name, :collection
 
+      # The default XML namespace which should be used for building the XML
+      #   Document transmitted in the body of the HTTP request
+      # @return [String]
+      def self.default_xml_namespace
+        "tigerdata"
+      end
+
       # Constructor
       # @param session_token [String] the API token for the authenticated session
       # @param name [String] Name of the Asset
@@ -16,7 +23,7 @@ module Mediaflux
         @asset_name = name
         @collection = collection
         @tigerdata_values = tigerdata_values
-        @xml_namespace = xml_namespace
+        @xml_namespace = xml_namespace || self.class.default_xml_namespace
       end
 
       # Specifies the Mediaflux service to use when creating assets

--- a/app/models/mediaflux/http/create_asset_request.rb
+++ b/app/models/mediaflux/http/create_asset_request.rb
@@ -9,12 +9,14 @@ module Mediaflux
       # @param name [String] Name of the Asset
       # @param collection [Boolean] create a collection asset if true
       # @param namespace [String] Optional Parent namespace for the asset to be created in
-      def initialize(session_token:, namespace: nil, name:, collection: true, tigerdata_values: nil)
+      # @param xml_namespace [String]
+      def initialize(session_token:, namespace: nil, name:, collection: true, tigerdata_values: nil, xml_namespace: nil)
         super(session_token: session_token)
         @namespace = namespace
         @asset_name = name
         @collection = collection
         @tigerdata_values = tigerdata_values
+        @xml_namespace = xml_namespace
       end
 
       # Specifies the Mediaflux service to use when creating assets
@@ -41,6 +43,7 @@ module Mediaflux
         #     >
         #
         # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/AbcSize
         def build_http_request_body(name:)
           super do |xml|
@@ -57,19 +60,23 @@ module Mediaflux
                   # in request.rb
                   #
                   # See also https://nokogiri.org/rdoc/Nokogiri/XML/Builder.html
-                  xml.send("tigerdata:project", "xmlns" => "tigerdata:project") do
+                  element_name = @xml_namespace.nil? ? "project" : "#{@xml_namespace}:project"
+                  xml.send(element_name, "xmlns" => element_name) do
                     xml.code @tigerdata_values[:code]
                     xml.title @tigerdata_values[:title]
                     xml.description @tigerdata_values[:description]
                     xml.data_sponsor @tigerdata_values[:data_sponsor]
                     xml.data_manager @tigerdata_values[:data_manager]
-                    @tigerdata_values[:departments].each do |department|
+                    departments = @tigerdata_values[:departments] || []
+                    departments.each do |department|
                       xml.departments department
                     end
-                    @tigerdata_values[:data_user_read_only].each do |ro_user|
+                    ro_users = @tigerdata_values[:data_user_read_only] || []
+                    ro_users.each do |ro_user|
                       xml.data_users_ro ro_user
                     end
-                    @tigerdata_values[:data_user_read_write].each do |rw_user|
+                    rw_users = @tigerdata_values[:data_user_read_write] || []
+                    rw_users.each do |rw_user|
                       xml.data_users_rw rw_user
                     end
                     xml.created_on @tigerdata_values[:created_on]
@@ -90,6 +97,7 @@ module Mediaflux
           end
         end
       # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
     end
   end

--- a/app/models/mediaflux/http/request.rb
+++ b/app/models/mediaflux/http/request.rb
@@ -129,7 +129,7 @@ module Mediaflux
           args = { name: name }
           args[:session] = session_token unless session_token.nil?
 
-          Nokogiri::XML::Builder.new do |xml|
+          Nokogiri::XML::Builder.new(namespace_inheritance: false) do |xml|
             xml.request do
               xml.service(**args) do
                 yield xml if block_given?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,8 +30,8 @@ class Project < ApplicationRecord
     Project.where("metadata_json->>'data_sponsor' = ?", sponsor)
   end
 
-  def approve!(session_id:, created_by: netid)
-    asset_id = ProjectMediaflux.create!(project: self, session_id: session_id, created_by: created_by)
+  def approve!(session_id:, created_by: netid, xml_namespace: nil)
+    asset_id = ProjectMediaflux.create!(project: self, session_id: session_id, created_by: created_by, xml_namespace: xml_namespace)
     if asset_id.present?
       Rails.logger.debug "Project #{id} has been saved to MediaFlux (asset id #{asset_id.to_i})"
       self.mediaflux_id = asset_id.to_i

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ProjectMediaflux
-  def self.create!(project:, session_id:, created_by:)
+  def self.create!(project:, session_id:, created_by:, xml_namespace: nil)
     store_name = Store.default(session_id: session_id).name
 
     # Make sure the root namespace exists
@@ -14,7 +14,8 @@ class ProjectMediaflux
 
     # Create a collection asset under the new namespace and set its metadata
     tigerdata_values = project_values(project: project, created_by: created_by)
-    create_request = Mediaflux::Http::CreateAssetRequest.new(session_token: session_id, namespace: project_namespace, name: project_name, tigerdata_values: tigerdata_values)
+    create_request = Mediaflux::Http::CreateAssetRequest.new(session_token: session_id, namespace: project_namespace, name: project_name, tigerdata_values: tigerdata_values,
+                                                             xml_namespace: xml_namespace)
     create_request.resolve
     create_request.id
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "/projects", type: :request do
+  describe "POST /projects" do
+    let(:data_manager) { nil }
+    let(:data_sponsor) { nil }
+    let(:data_user_read_only) { nil }
+    let(:data_user_read_write) { nil }
+    let(:departments) { nil }
+    let(:description) { nil }
+    let(:directory) { nil }
+    let(:title) { nil }
+    let(:params) do
+      {
+        data_manager: data_manager,
+        data_sponsor: data_sponsor,
+        data_user_read_only: data_user_read_only,
+        data_user_read_write: data_user_read_write,
+        departments: departments,
+        description: description,
+        directory: directory,
+        title: title
+      }
+    end
+
+    it "redirects the client to the sign in path" do
+      post(projects_path, params: params)
+
+      expect(response).to be_redirect
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    context "when the client is authenticated" do
+      let(:user) { FactoryBot.create(:user, uid: "pul123") }
+      let(:response_body) do
+        filename = Rails.root.join("spec", "fixtures", "files", "version_response.xml")
+        File.new(filename).read
+      end
+
+      before do
+        sign_in user
+      end
+
+      it "renders a successful response" do
+        post(projects_path, params: params)
+
+        expect(response).to be_redirect
+        expect(Project.all).not_to be_empty
+        new_project = Project.last
+        expect(response).to redirect_to(project_path(new_project))
+      end
+    end
+  end
+
+  describe "POST /projects/:id/approve" do
+    let(:user) { FactoryBot.create(:user, uid: "pul123") }
+    let(:project) do
+      FactoryBot.create(:project,
+                        metadata: {
+                          title: "foo",
+                          directory: "big-data",
+                          departments: ["RDSS"],
+                          description: "test2",
+                          data_manager: "test3",
+                          data_sponsor: "test4"
+                        })
+    end
+    let(:mediaflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+    let(:mediaflux_login_fixture_path) do
+      Rails.root.join("spec", "fixtures", "files", "login_response.xml")
+    end
+    let(:mediaflux_login_body) do
+      File.read(mediaflux_login_fixture_path)
+    end
+    let(:mediaflux_create_fixture_path) do
+      Rails.root.join("spec", "fixtures", "files", "asset_create_response.xml")
+    end
+    let(:mediaflux_create_body) do
+      File.read(mediaflux_create_fixture_path)
+    end
+    let(:store) { instance_double(Store) }
+
+    before do
+      allow(store).to receive(:name).and_return("test")
+      allow(Store).to receive(:all).and_return([store])
+
+      stub_request(:post, mediaflux_url).to_return(
+        {
+          status: 200,
+          body: mediaflux_login_body
+        },
+        {
+          status: 200,
+          body: mediaflux_create_body
+        }
+      )
+
+      project
+      sign_in(user)
+    end
+
+    context "when the client is authenticated" do
+      let(:create_project_body) do
+        <<-XML
+<?xml version="1.0"?>
+<request>
+  <service name="asset.create" session="sessiontoken">
+    <args>
+      <name>big-data</name>
+      <namespace>/td-test-001/big-data-ns</namespace>
+      <meta>
+        <project xmlns="project">
+          <code>big-data</code>
+          <title>foo</title>
+          <description>test2</description>
+          <data_sponsor>test4</data_sponsor>
+          <data_manager>test3</data_manager>
+          <departments>RDSS</departments>
+          <created_on>now</created_on>
+          <created_by>pul123</created_by>
+        </project>
+      </meta>
+      <collection cascade-contained-asset-index="true" contained-asset-index="true" unique-name-index="true">true</collection>
+      <type>application/arc-asset-collection</type>
+    </args>
+  </service>
+</request>
+XML
+      end
+
+      it "creates the project asset within mediaflux" do
+        post(project_approve_path(project))
+
+        expect(response).to redirect_to(project_path(project))
+
+        project.reload
+        expect(project.in_mediaflux?).to be true
+        # this ensures that the request was transmitted as expected
+        expect(a_request(:post, mediaflux_url).with(
+          body: create_project_body
+        )).to have_been_made.once
+      end
+
+      context "when a namespace is specified" do
+        let(:project) do
+          FactoryBot.create(:project,
+                            metadata: {
+                              title: "foo",
+                              directory: "big-data",
+                              departments: ["RDSS"],
+                              description: "test2",
+                              data_manager: "test3",
+                              data_sponsor: "test4"
+                            })
+        end
+
+        it "creates the mediaflux project asset using the namespace" do
+          post(project_approve_path(project, params: { xml_namespace: "bar" }))
+
+          expect(response).to redirect_to(project_path(project))
+
+          project.reload
+          expect(project.in_mediaflux?).to be true
+          # this ensures that the request was transmitted as expected
+          expect(a_request(:post, mediaflux_url).with(
+            body: /<bar:project xmlns="bar:project"/
+          )).to have_been_made.once
+
+          expect(a_request(:post, mediaflux_url).with(
+            body: /<\/bar:project>/
+          )).to have_been_made.once
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "/projects", type: :request do
       <name>big-data</name>
       <namespace>/td-test-001/big-data-ns</namespace>
       <meta>
-        <project xmlns="project">
+        <tigerdata:project xmlns:tigerdata="tigerdata">
           <code>big-data</code>
           <title>foo</title>
           <description>test2</description>
@@ -119,7 +119,7 @@ RSpec.describe "/projects", type: :request do
           <departments>RDSS</departments>
           <created_on>now</created_on>
           <created_by>pul123</created_by>
-        </project>
+        </tigerdata:project>
       </meta>
       <collection cascade-contained-asset-index="true" contained-asset-index="true" unique-name-index="true">true</collection>
       <type>application/arc-asset-collection</type>


### PR DESCRIPTION
Resolves #227 