### PR TITLE
Ensuring that the create and update HTTP requests for Mediaflux have XML documents with the proper namespaces for the request body

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,13 +16,14 @@ AllCops:
 
 Layout/IndentationConsistency:
   EnforcedStyle: indented_internal_methods
-  
+
 Layout/LineLength:
   Exclude:
     - "spec/system/data_migration/*"
 
 Metrics/BlockLength:
   Exclude:
+    - "app/models/mediaflux/http/create_asset_request.rb"
     - "config/environments/**/*"
     - "lib/tasks/**/*"
     - "spec/**/*"

--- a/app/models/mediaflux/http/request.rb
+++ b/app/models/mediaflux/http/request.rb
@@ -155,11 +155,6 @@ module Mediaflux
           body = build_http_request_body(name: name)
           xml_payload = body.to_xml
 
-          # TODO: This horrible hack should be removed once we address
-          # GitHub issue: https://github.com/pulibrary/tiger-data-app/issues/227
-          #
-          # See create_asset_request.rb and update_asset_request.rb for more information.
-
           Rails.logger.debug(xml_payload)
           if form_file.nil?
             request["Content-Type"] = "text/xml; charset=utf-8"

--- a/app/models/mediaflux/http/request.rb
+++ b/app/models/mediaflux/http/request.rb
@@ -49,6 +49,17 @@ module Mediaflux
         Rails.configuration.mediaflux["api_port"].to_i
       end
 
+      # The default XML namespace which should be used for building the XML
+      #   Document transmitted in the body of the HTTP request
+      # @return [String]
+      def self.default_xml_namespace
+        "tigerdata"
+      end
+
+      def self.default_xml_namespace_uri
+        "http://tigerdata.princeton.edu"
+      end
+
       attr_reader :session_token
 
       # Constructor
@@ -148,9 +159,6 @@ module Mediaflux
           # GitHub issue: https://github.com/pulibrary/tiger-data-app/issues/227
           #
           # See create_asset_request.rb and update_asset_request.rb for more information.
-          if xml_payload.include?("asset.create") || xml_payload.include?("asset.set")
-            xml_payload.gsub!('xmlns="tigerdata:project"', 'xmlns:tigerdata="tigerdata"')
-          end
 
           Rails.logger.debug(xml_payload)
           if form_file.nil?

--- a/app/models/mediaflux/http/update_asset_request.rb
+++ b/app/models/mediaflux/http/update_asset_request.rb
@@ -6,10 +6,13 @@ module Mediaflux
       # @param session_token [String] the API token for the authenticated session
       # @param id [Int] Mediaflux asset ID of the asset to update
       # @param tigerdata_values [Hash] Values to update in the asset metadata
-      def initialize(session_token:, id:, tigerdata_values:)
+      # @param xml_namespace [String] XML namespace for the <project> element
+      def initialize(session_token:, id:, tigerdata_values:, xml_namespace: nil, xml_namespace_uri: nil)
         super(session_token: session_token)
         @id = id
         @tigerdata_values = tigerdata_values
+        @xml_namespace = xml_namespace || self.class.default_xml_namespace
+        @xml_namespace_uri = xml_namespace_uri || self.class.default_xml_namespace_uri
       end
 
       # Specifies the Mediaflux service to use when updating assets
@@ -38,15 +41,13 @@ module Mediaflux
               xml.id @id
               if @tigerdata_values
                 xml.meta do
-                  # TODO: The parameters to xml.send() need to be adjusted as indicated on
-                  # GitHub issue https://github.com/pulibrary/tiger-data-app/issues/227
-                  #
-                  # The values we are passing right here produce the correct XML
-                  # structure but the wrong xmlns value, which we manually adjust
-                  # in request.rb
-                  #
-                  # See also https://nokogiri.org/rdoc/Nokogiri/XML/Builder.html
-                  xml.send("tigerdata:project", "xmlns" => "tigerdata:project") do
+                  doc = xml.doc
+                  root = doc.root
+                  # Define the namespace only if this is required
+                  root.add_namespace_definition(@xml_namespace, @xml_namespace_uri)
+
+                  element_name = @xml_namespace.nil? ? "project" : "#{@xml_namespace}:project"
+                  xml.send(element_name) do
                     xml.code @tigerdata_values[:code]
                     xml.title @tigerdata_values[:title]
                     xml.description @tigerdata_values[:description]

--- a/spec/fixtures/files/asset_update_request.xml
+++ b/spec/fixtures/files/asset_update_request.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<request>
+<request xmlns:tigerdata="http://tigerdata.princeton.edu">
   <service name="asset.set" session="secretsecret/2/31">
     <args>
       <id>1234</id>
       <meta>
-        <tigerdata:project xmlns:tigerdata="tigerdata">
+        <tigerdata:project>
           <code>code</code>
           <title>title</title>
           <description>description</description>

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -104,13 +104,13 @@ RSpec.describe "/projects", type: :request do
       let(:create_project_body) do
         <<-XML
 <?xml version="1.0"?>
-<request>
+<request xmlns:tigerdata="http://tigerdata.princeton.edu">
   <service name="asset.create" session="sessiontoken">
     <args>
       <name>big-data</name>
       <namespace>/td-test-001/big-data-ns</namespace>
       <meta>
-        <tigerdata:project xmlns:tigerdata="tigerdata">
+        <tigerdata:project>
           <code>big-data</code>
           <title>foo</title>
           <description>test2</description>
@@ -164,7 +164,7 @@ XML
           expect(project.in_mediaflux?).to be true
           # this ensures that the request was transmitted as expected
           expect(a_request(:post, mediaflux_url).with(
-            body: /<bar:project xmlns="bar:project"/
+            body: /<bar:project/
           )).to have_been_made.once
 
           expect(a_request(:post, mediaflux_url).with(


### PR DESCRIPTION
Resolves #227 