### PR TITLE
264 project detail page headings

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -68,7 +68,6 @@ class ProjectsController < ApplicationController
 
     def project_timestamps(project:)
       timestamps = {}
-      # TODO: Use the correct dates instead of the hard coded ones
       if project.nil?
         timestamps[:created_by] = current_user.uid
         timestamps[:created_on] = DateTime.now.strftime("%d-%b-%Y %H:%M:%S")

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,12 +71,13 @@ class ProjectsController < ApplicationController
       # TODO: Use the correct dates instead of the hard coded ones
       if project.nil?
         timestamps[:created_by] = current_user.uid
-        timestamps[:created_on] = "07-Dec-2023 17:22:22"
+        timestamps[:created_on] = DateTime.now.strftime("%d-%b-%Y %H:%M:%S")
+
       else
         timestamps[:created_by] = project.metadata[:created_by]
         timestamps[:created_on] = project.metadata[:created_on]
         timestamps[:updated_by] = current_user.uid
-        timestamps[:updated_on] = "08-Dec-2023 17:22:22"
+        timestamps[:updated_on] = DateTime.now.strftime("%d-%b-%Y %H:%M:%S")
       end
       timestamps
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,6 +16,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = Project.find(params[:id])
+    debugger
   end
 
   def approve

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -66,6 +66,21 @@ class ProjectsController < ApplicationController
       users.compact.uniq
     end
 
+    def project_timestamps(project:)
+      timestamps = {}
+      # TODO: Use the correct dates instead of the hard coded ones
+      if project.nil?
+        timestamps[:created_by] = current_user.uid
+        timestamps[:created_on] = "07-Dec-2023 17:22:22"
+      else
+        timestamps[:created_by] = project.metadata[:created_by]
+        timestamps[:created_on] = project.metadata[:created_on]
+        timestamps[:updated_by] = current_user.uid
+        timestamps[:updated_on] = "08-Dec-2023 17:22:22"
+      end
+      timestamps
+    end
+
     def form_metadata(project: nil)
       ro_users = user_list_params(read_only_counter, "ro_user_")
       rw_users = user_list_params(read_write_counter, "rw_user_")
@@ -79,17 +94,7 @@ class ProjectsController < ApplicationController
         data_user_read_only: ro_users,
         data_user_read_write: rw_users
       }
-
-      # TODO: Use the correct dates instead of the hard coded ones
-      if project.nil?
-        data[:created_by] = current_user.uid
-        data[:created_on] = "07-Dec-2023 17:22:22"
-      else
-        data[:created_by] = project.metadata[:created_by]
-        data[:created_on] = project.metadata[:created_on]
-        data[:updated_by] = current_user.uid
-        data[:updated_on] = "08-Dec-2023 17:22:22"
-      end
-      data
+      timestamps = project_timestamps(project: project)
+      data.merge(timestamps)
     end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,8 +30,8 @@ class Project < ApplicationRecord
     Project.where("metadata_json->>'data_sponsor' = ?", sponsor)
   end
 
-  def approve!(session_id:, created_by: netid, xml_namespace: nil)
-    asset_id = ProjectMediaflux.create!(project: self, session_id: session_id, created_by: created_by, xml_namespace: xml_namespace)
+  def approve!(session_id:, xml_namespace: nil)
+    asset_id = ProjectMediaflux.create!(project: self, session_id: session_id, xml_namespace: xml_namespace)
     if asset_id.present?
       Rails.logger.debug "Project #{id} has been saved to MediaFlux (asset id #{asset_id.to_i})"
       self.mediaflux_id = asset_id.to_i
@@ -41,8 +41,8 @@ class Project < ApplicationRecord
     end
   end
 
-  def update_mediaflux(session_id:, updated_by:)
-    ProjectMediaflux.update(project: self, session_id: session_id, updated_by: updated_by)
+  def update_mediaflux(session_id:)
+    ProjectMediaflux.update(project: self, session_id: session_id)
     Rails.logger.debug "Project #{id} has been updated in MediaFlux (asset id #{mediaflux_id}"
   end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -39,12 +39,27 @@ Project Details:
   </p>
 </div>
 
+<%
+=begin%>
+  INSERT 2 DIVS. ONE FOR AUTOMATIC SETTINGS -- CONTAINING THE MEDIAFLUX ID -- AND ONE FOR PROVENANCE -- CONTAINING CREATEDBY/ON AND UPDATED BY/ON -- BOTH SHOULD BE ACCESSIBLE VIA  `project.metadata`
+<%
+=end%>
+
 <div>
+  <h2>Automatic Settings </h2>
   <% if @project.in_mediaflux? %>
     <p>Mediaflux id: <%= @project.mediaflux_id %></p>
   <% else %>
     <p>This project has not been saved to Mediaflux</p>
   <% end %>
+</div>
+
+<div>
+  <h2> Provenance </h2>
+  <p>Created On: <%= @project.metadata[:created_on] %> </p>
+  <p>Created By: <%= @project.metadata[:created_by] %> </p>
+  <p>Updated On: <%= @project.metadata[:updated_on] %> </p>
+  <p>Updated By: <%= @project.metadata[:updated_by] %> </p>
 </div>
 
 <div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -39,12 +39,6 @@ Project Details:
   </p>
 </div>
 
-<%
-=begin%>
-  INSERT 2 DIVS. ONE FOR AUTOMATIC SETTINGS -- CONTAINING THE MEDIAFLUX ID -- AND ONE FOR PROVENANCE -- CONTAINING CREATEDBY/ON AND UPDATED BY/ON -- BOTH SHOULD BE ACCESSIBLE VIA  `project.metadata`
-<%
-=end%>
-
 <div>
   <h2>Automatic Settings </h2>
   <% if @project.in_mediaflux? %>

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
     end
 
     it "creates a project namespace and collection and returns the mediaflux id" do
-      mediaflux_id = described_class.create!(project: project, session_id: "test-session-token", created_by: "pul123")
+      mediaflux_id = described_class.create!(project: project, session_id: "test-session-token")
       expect(namespace_request).to have_received("resolve")
       expect(create_asset_request).to have_received("resolve")
       expect(mediaflux_id).to be "123"

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe "/projects", type: :request do
                           departments: ["RDSS"],
                           description: "test2",
                           data_manager: "test3",
-                          data_sponsor: "test4"
+                          data_sponsor: "test4",
+                          created_by: "pul123",
+                          created_on: "07-Dec-2023 17:22:22"
                         })
     end
     let(:mediaflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
@@ -117,7 +119,7 @@ RSpec.describe "/projects", type: :request do
           <data_sponsor>test4</data_sponsor>
           <data_manager>test3</data_manager>
           <departments>RDSS</departments>
-          <created_on>now</created_on>
+          <created_on>07-Dec-2023 17:22:22</created_on>
           <created_by>pul123</created_by>
         </tigerdata:project>
       </meta>

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
 
   let(:project_in_mediaflux) do
     project = FactoryBot.create(:project, metadata: metadata)
-    project.approve!(session_id: sponsor_user.mediaflux_session, created_by: sponsor_user.uid)
+    project.approve!(session_id: sponsor_user.mediaflux_session)
     project
   end
 


### PR DESCRIPTION
Adds the `created_by/on` and `updated_by/on` to the "Provenance" section of the Show page. 

We had to do a little bit of refactoring to the code since @JaymeeH noticed that we were not persisting these values in the `medata_json` field.

Closes #264 