### PR TITLE
Pre-populate current user's netid as data sponsor when making a new project

### DIFF
--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# Helper methods for projects
+module ProjectHelper
+  # For a new project form, pre-populate the data sponsor field with the current user's netid.
+  # For an existing project form, pre-populate the data sponsor field with the current value.
+  def pre_populate_data_sponsor
+    if @project.metadata[:data_sponsor].nil?
+      current_user.uid
+    else
+      @project.metadata[:data_sponsor]
+    end
+  end
+end

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -21,7 +21,7 @@
 <div>
   <h2>Project Roles</h2>
 
-  <p>Data Sponsor: <input type="text" id="data_sponsor" name="data_sponsor" required autofocus value="<%= @project.metadata[:data_sponsor] %>" /></p>
+  <p>Data Sponsor: <input type="text" id="data_sponsor" name="data_sponsor" required autofocus value="<%= pre_populate_data_sponsor %>" /></p>
   <p>Data Manager: <input type="text" id="data_manager" name="data_manager" required value="<%= @project.metadata[:data_manager] %>" /></p>
   <p>Data User(s): </p>
 

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -114,12 +114,17 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
   end
 
   context "Edit page" do
-    it "preserves the readonly directory field" do
+    before do
       sign_in sponsor_user
       visit "/projects/#{project_in_mediaflux.id}/edit"
+    end
+    it "preserves the readonly directory field" do
       click_on "Save"
       project_in_mediaflux.reload
       expect(project_in_mediaflux.metadata[:directory]).to eq "project-123"
+    end
+    it "loads existing content into the form" do
+      expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
     end
   end
 
@@ -129,7 +134,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       sign_in sponsor_user
       visit "/"
       click_on "New Project"
-      fill_in "data_sponsor", with: sponsor_user.uid
+      expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
       fill_in "data_manager", with: data_manager.uid
       fill_in "ro-user-uid-to-add", with: read_only.uid
       click_on "btn-add-ro-user"


### PR DESCRIPTION
Ref #252 