### PR TITLE
Extending the project form input validation

### DIFF
--- a/app/javascript/entrypoints/user_datalist.js
+++ b/app/javascript/entrypoints/user_datalist.js
@@ -2,11 +2,15 @@
 // Code idea taken from https://www.jotform.com/blog/html5-datalists-what-you-need-to-know-78024/
 export default class UserDatalist {
   setupDatalistValidity() {
-  // Find all inputs on the DOM which are bound to a datalist via their list attribute.
+    // Find all inputs on the DOM which are bound to a datalist via their list attribute.
     const inputs = document.querySelectorAll('input[list]');
     for (let i = 0; i < inputs.length; i += 1) {
-    // When the value of the input changes...
-      inputs[i].addEventListener('change', this.userRoleChange);
+      // When the value of the input changes...
+      const element = inputs[i];
+      element.addEventListener('change', this.userRoleChange);
+
+      // This is necessary for the initial page load
+      this.userRoleChange.apply(element);
     }
   }
 
@@ -24,19 +28,29 @@ export default class UserDatalist {
     // to provide an user feedback if the value does not exist in the datalist
     if (optionFound) {
       this.setCustomValidity('');
-      this.parentNode.querySelectorAll('a');
-      const buttons = this.parentNode.querySelectorAll('[type=submit]');
-      for (let k = 0; k < buttons.length; k += 1) {
-        buttons[k].disabled = false;
+    } else if (this.required || this.value !== '') {
+      this.setCustomValidity('Please select a valid value.');
+    }
+
+    const buttons = this.parentNode.querySelectorAll('[type=Submit]');
+    if (this.value !== '') {
+      for (let x = 0; x < buttons.length; x += 1) {
+        buttons[x].disabled = !optionFound;
       }
     } else {
-      this.setCustomValidity('Please select a valid value.');
-      const buttons = this.parentNode.querySelectorAll('[type=submit]');
       for (let x = 0; x < buttons.length; x += 1) {
         buttons[x].disabled = true;
       }
     }
-    // tell the user if there are errors
-    this.reportValidity();
+
+    if (this.required) {
+      const formButtons = this.form.querySelectorAll('[value=Submit]');
+      for (let k = 0; k < formButtons.length; k += 1) {
+        formButtons[k].disabled = !optionFound;
+      }
+
+      // tell the user if there are errors
+      this.reportValidity();
+    }
   }
 }

--- a/spec/system/project_roles_spec.rb
+++ b/spec/system/project_roles_spec.rb
@@ -22,48 +22,51 @@ RSpec.describe "Project Edit Page Roles Validation", type: :system do
     click_on "New Project"
     expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
     fill_in "data_sponsor", with: ""
-    click_on "Submit"
+    expect(page.find("input[value=Submit]")).to be_disabled
     expect(page.find("#data_sponsor").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "data_sponsor", with: "xxx"
-    click_on "Submit"
+    expect(page.find("input[value=Submit]")).to be_disabled
     expect(page.find("#data_sponsor").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "data_sponsor", with: sponsor_user.uid
+    page.find("body").click
     click_on "Submit"
     expect(page.find("#data_sponsor").native.attribute("validationMessage")).to eq ""
 
     fill_in "data_manager", with: "xxx"
-    click_on "Submit"
+    page.find("body").click
+    expect(page.find("input[value=Submit]")).to be_disabled
     expect(page.find("#data_manager").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "data_manager", with: ""
-    click_on "Submit"
+    expect(page.find("input[value=Submit]")).to be_disabled
     expect(page.find("#data_manager").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "data_manager", with: data_manager.uid
+    page.find("body").click
     click_on "Submit"
     expect(page.find("#data_manager").native.attribute("validationMessage")).to eq ""
 
-    # clicking on Save becuase once the button is disabled it does not get reenabled until after the user clicks out of the text box
+    # clicking on Save because once the button is disabled it does not get reenabled until after the user clicks out of the text box
     fill_in "ro-user-uid-to-add", with: "xxx"
-    click_on "Submit"
-    expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
+    page.find("body").click
     expect(page.find("#btn-add-ro-user")).to be_disabled
+    expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "ro-user-uid-to-add", with: ""
-    click_on "Submit"
-    expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
+    page.find("body").click
     expect(page.find("#btn-add-ro-user")).to be_disabled
+    expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "ro-user-uid-to-add", with: read_only.uid
-    click_on "Submit"
+    page.find("body").click
     click_on "btn-add-ro-user"
     expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq ""
 
-    # clicking on Save becuase once the button is disabled it does not get reenabled until after the user clicks out of the text box
+    # clicking on Save because once the button is disabled it does not get reenabled until after the user clicks out of the text box
     fill_in "rw-user-uid-to-add", with: "xxx"
-    click_on "Submit"
-    expect(page.find("#rw-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
+    page.find("body").click
     expect(page.find("#btn-add-rw-user")).to be_disabled
+    expect(page.find("#rw-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "rw-user-uid-to-add", with: ""
-    click_on "Submit"
-    expect(page.find("#rw-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
+    page.find("body").click
     expect(page.find("#btn-add-rw-user")).to be_disabled
+    expect(page.find("#rw-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
     fill_in "rw-user-uid-to-add", with: read_write.uid
     click_on "Submit"
     click_on "btn-add-rw-user"

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -127,8 +127,12 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
       fill_in "data_manager", with: data_manager.uid
       fill_in "ro-user-uid-to-add", with: read_only.uid
+      # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+      page.find("body").click
       click_on "btn-add-ro-user"
       fill_in "rw-user-uid-to-add", with: read_write.uid
+      # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+      page.find("body").click
       click_on "btn-add-rw-user"
       fill_in "directory", with: "test_project"
       fill_in "title", with: "My test project"
@@ -153,7 +157,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       click_on "New Project"
       expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
       fill_in "data_sponsor", with: ""
-      click_on "Submit"
+      expect(page.find("input[value=Submit]")).to be_disabled
       expect(page.find("#data_sponsor").native.attribute("validationMessage")).to eq "Please select a valid value."
     end
     context "with an invalid data manager" do
@@ -162,19 +166,20 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         visit "/"
         click_on "New Project"
         expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
-        # fill_in "data_sponsor", with: sponsor_user.uid
         fill_in "data_manager", with: "xxx"
-        fill_in "ro-user-uid-to-add", with: read_only.uid
         expect(page.find("#data_manager").native.attribute("validationMessage")).to eq "Please select a valid value."
+        fill_in "ro-user-uid-to-add", with: read_only.uid
+        # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+        page.find("body").click
         click_on "btn-add-ro-user"
         fill_in "rw-user-uid-to-add", with: read_write.uid
+        # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+        page.find("body").click
         click_on "btn-add-rw-user"
         fill_in "directory", with: "test_project"
         fill_in "title", with: "My test project"
         expect(page).to have_content("Project Directory: /td-test-001/")
-        expect do
-          click_on "Submit"
-        end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(1).times
+        expect(page.find("input[value=Submit]")).to be_disabled
       end
     end
 
@@ -186,11 +191,11 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         expect(page.find("#data_sponsor").value).to eq sponsor_user.uid
         fill_in "data_manager", with: data_manager.uid
         fill_in "ro-user-uid-to-add", with: "xxx"
-        click_on "btn-add-ro-user"
+        page.find("body").click
         expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
 
         fill_in "rw-user-uid-to-add", with: "zzz"
-        click_on "btn-add-rw-user"
+        page.find("body").click
         expect(page.find("#ro-user-uid-to-add").native.attribute("validationMessage")).to eq "Please select a valid value."
         fill_in "directory", with: "test_project"
         fill_in "title", with: "My test project"
@@ -217,8 +222,10 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         fill_in "data_sponsor", with: sponsor_user.uid
         fill_in "data_manager", with: data_manager.uid
         fill_in "ro-user-uid-to-add", with: read_only.uid
+        page.find("body").click
         click_on "btn-add-ro-user"
         fill_in "rw-user-uid-to-add", with: read_write.uid
+        page.find("body").click
         click_on "btn-add-rw-user"
         fill_in "directory", with: "test?project"
         valid = page.find("input#directory:invalid")


### PR DESCRIPTION
Ensuring that the project form validation does not raise errors for cases where the data sponsors and data managers are specified, but the read-only and read/write users are not. These changes were necessary to propose when testing the changes found within https://github.com/pulibrary/tiger-data-app/pull/350