### PR TITLE
Adding an accumulator task so folks can create accumulators

### DIFF
--- a/app/models/mediaflux/http/create_collection_accumulator_request.rb
+++ b/app/models/mediaflux/http/create_collection_accumulator_request.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class CreateCollectionAccumulatorRequest < Request
+      attr_reader :namespace, :asset_name, :collection
+
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      # @param collection [String] Id of the collection
+      # @param name [String] Name of the Accumulator
+      # @param type [String] type of the Accumulator
+      #     	"collection.asset.count"
+      #      	"content.all.copy.tag.size"
+      #     	"content.all.size"
+      #      	"content.all.store.size"
+      #      	"content.all.store.size.by.owner"
+      #      	"content.all.store.size.by.xpath"
+      #      	"content.all.type.size"
+      def initialize(session_token:, collection:, name:, type:)
+        super(session_token: session_token)
+        @name = name
+        @collection = collection
+        @type = type
+      end
+
+      # Specifies the Mediaflux service to use when creating assets
+      # @return [String]
+      def self.service
+        "asset.collection.accumulator.add"
+      end
+
+      private
+
+        # The generated XML mimics what we get when we issue an Aterm command as follows:
+        # > asset.collection.accumulator.add :id 3218 :cascade true
+        #      :accumulator < :name mytest-01509-count :type collection.asset.count >
+        #
+        def build_http_request_body(name:)
+          super do |xml|
+            xml.args do
+              xml.id @collection
+              xml.cascade true
+              xml.accumulator do
+                xml.name @name
+                xml.type @type
+              end
+            end
+          end
+        end
+    end
+  end
+end

--- a/spec/fixtures/files/asset_collection_accumulator_add_response.xml
+++ b/spec/fixtures/files/asset_collection_accumulator_add_response.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+    <reply type="result">
+        <result>
+            <added id="1197">1</added>
+        </result>
+    </reply>
+</response>

--- a/spec/models/mediaflux/http/create_collection_accumulator_request_spec.rb
+++ b/spec/models/mediaflux/http/create_collection_accumulator_request_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::Http::CreateCollectionAccumulatorRequest, type: :model do
+  let(:mediflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+
+  let(:create_response) do
+    filename = Rails.root.join("spec", "fixtures", "files", "asset_collection_accumulator_add_response.xml")
+    File.new(filename).read
+  end
+
+  describe "#resolve" do
+    before do
+      stub_request(:post, mediflux_url)
+        .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.collection.accumulator.add\" session=\"secretsecret/2/31\">\n"\
+                    "    <args>\n      <id>1234</id>\n      <cascade>true</cascade>\n      <accumulator>\n        <name>testasset</name>\n        <type>collection.asset.count</type>\n"\
+                    "      </accumulator>\n    </args>\n  </service>\n</request>\n")
+        .to_return(status: 200, body: create_response, headers: {})
+    end
+
+    it "parses a response" do
+      create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", collection: "1234", type: "collection.asset.count")
+      response = create_request.resolve
+      expect(response.code).to eq("200")
+      expect(a_request(:post, mediflux_url).with do |req|
+        req.body.include?("<name>testasset</name>")
+      end).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
An example of running it in the console...
```
user = User.first
collection = 1234 # exisiting collection id
accum = Mediaflux::Http::CreateCollectionAccumulatorRequest.new(session_token: user.mediaflux_session, collection:, name: test-asset-create-count2,  type:collection.asset.count)
accum.resolve
accum.response_xml
```
Should give you something like
```
<response><reply type="result"><result><added id="1197">7</added></result></reply></response>
```