### PR TITLE
Fix mediaflux query to include all children and sub-collections

### DIFF
--- a/app/models/mediaflux/http/query_request.rb
+++ b/app/models/mediaflux/http/query_request.rb
@@ -51,7 +51,7 @@ module Mediaflux
               # TODO: there is a bug in mediaflux that does not allow the comented out line to paginate
               #      For the moment we will utilize the where clasue that does allow pagination
               # xml.collection collection if collection.present?
-              xml.where "asset in collection #{collection}" if collection.present?
+              xml.where "asset in collection or subcollection of #{collection}" if collection.present?
               xml.where aql_query if aql_query.present?
               xml.action action if action.present?
               xml.idx idx

--- a/spec/models/mediaflux/http/query_request_spec.rb
+++ b/spec/models/mediaflux/http/query_request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Mediaflux::Http::QueryRequest, type: :model do
       before do
         stub_request(:post, mediflux_url)
           .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.query\" session=\"secretsecret/2/31\">\n    "\
-                      "<args>\n      <where>asset in collection 1067</where>\n      <idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
+                      "<args>\n      <where>asset in collection or subcollection of 1067</where>\n      <idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
           .to_return(status: 200, body: query_response, headers: {})
       end
 
@@ -73,7 +73,8 @@ RSpec.describe Mediaflux::Http::QueryRequest, type: :model do
         before do
           stub_request(:post, mediflux_url)
             .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.query\" session=\"secretsecret/2/31\">\n    "\
-            "<args>\n      <where>asset in collection 1067</where>\n      <action>get-name</action>\n      <idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
+            "<args>\n      <where>asset in collection or subcollection of 1067</where>\n      <action>get-name</action>\n      "\
+            "<idx>1</idx>\n      <size>10</size>\n    </args>\n  </service>\n</request>\n")
             .to_return(status: 200, body: name_query_response, headers: {})
         end
 


### PR DESCRIPTION
This more closely mimics having specified collection in the top level of the xml