### PR TITLE
Adding a range query for Mediaflux

### DIFF
--- a/app/models/mediaflux/http/range_query_request.rb
+++ b/app/models/mediaflux/http/range_query_request.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class RangeQueryRequest < Request
+      attr_reader :aql_query, :idx, :size, :collection, :namespace, :action
+
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      # @param collection [Integer] collection id
+      # @param xpath [String]  xpath expression for item to calculate the range against
+      def initialize(session_token:, collection: nil, xpath: nil)
+        super(session_token: session_token)
+        @collection = collection
+        @xpath = xpath
+      end
+
+      # Specifies the Mediaflux service to use when running a query
+      # @return [String]
+      def self.service
+        "asset.query"
+      end
+
+      # minimum value for xpath
+      def minimum
+        min_str = response_xml.xpath("/response/reply/result/value/min").text
+        min_str.to_i
+      end
+
+      # maximum value for xpath
+      def maximum
+        max_str = response_xml.xpath("/response/reply/result/value/max").text
+        max_str.to_i
+      end
+
+      private
+
+        def build_http_request_body(name:)
+          super do |xml|
+            xml.args do
+              xml.collection @collection
+              xml.action "range"
+              xml.xpath @xpath
+            end
+          end
+        end
+    end
+  end
+end

--- a/spec/fixtures/files/asset_query_range_size_response.xml
+++ b/spec/fixtures/files/asset_query_range_size_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <reply type="result">
+    <result>
+      <value nbe="54">
+        <min>100</min>
+        <max>55000</max>
+      </value>
+    </result>
+  </reply>
+</response>

--- a/spec/models/mediaflux/http/range_query_request_spec.rb
+++ b/spec/models/mediaflux/http/range_query_request_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::Http::RangeQueryRequest, type: :model do
+  let(:mediflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+
+  let(:query_response) do
+    filename = Rails.root.join("spec", "fixtures", "files", "asset_query_range_size_response.xml")
+    File.new(filename).read
+  end
+
+  before do
+    stub_request(:post, mediflux_url)
+      .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.query\" session=\"secretsecret/2/31\">\n    "\
+                  "<args>\n      <collection>1234</collection>\n      <action>range</action>\n      <xpath>content/size</xpath>\n    </args>\n  </service>\n</request>\n")
+      .to_return(status: 200, body: query_response, headers: {})
+  end
+
+  describe "#minimum" do
+    it "returns the minimum value" do
+      query_request = described_class.new(session_token: "secretsecret/2/31", xpath: "content/size", collection: 1234)
+      expect(query_request.minimum).to eq(100)
+      expect(WebMock).to have_requested(:post, mediflux_url)
+    end
+  end
+
+  describe "#maximum" do
+    it "returns the maximum value" do
+      query_request = described_class.new(session_token: "secretsecret/2/31", xpath: "content/size", collection: 1234)
+      expect(query_request.maximum).to eq(55_000)
+      expect(WebMock).to have_requested(:post, mediflux_url)
+    end
+  end
+end


### PR DESCRIPTION
Can be utilized to get the range of files sizes in a collection.

refs #392