### PR TITLE
Allowing Mediaflux test to run only locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - run: bundle exec rake db:migrate RAILS_ENV=test
       - run:
           name: Run Rspec
-          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/rspec/rspec.xml
+          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --tag \~no_ci --format progress --format RspecJunitFormatter -o /tmp/rspec/rspec.xml
       - store_test_results:
           path: /tmp/rspec
       - store_artifacts:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require "axe-rspec"
 require "devise"
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true,
-                             allow: "chromedriver.storage.googleapis.com")
+                             allow: ["chromedriver.storage.googleapis.com", "0.0.0.0"])
 # WebMock.enable_net_connect!
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |file| require file }
 

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
     context "Project Contents" do 
       let(:project) { FactoryBot.create(:project, project_id: "jh34", data_sponsor: sponsor_user.uid) }
       before do 
+        @original_api_host = Rails.configuration.mediaflux["api_host"]
+        Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
         session_id = sponsor_user.mediaflux_session
         
         # Create a project in mediaflux, attach an accumulator, and generate assests for the collection
@@ -64,9 +66,14 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
         accum_req.resolve
         TestAssetGenerator.new(user: sponsor_user, project_id: project.id, levels: 2, directory_per_level: 2, file_count_per_directory: 1).generate
       end
+
+      after do
+        Rails.configuration.mediaflux["api_host"] = @original_api_host
+      end
+
       # THIS PASSES LOCALLY, IF MEDIAFLUX IS RUNNING -- BUT MEDIAFLUX IS NOT IN OUR CI BUILD 
       # TODO: FIGURE OUT HOW TO REALLY TEST THIS
-      xit "Contents page has collection summary data" do
+      it "Contents page has collection summary data", :no_ci do
         # sign in and be able to view the file count for the collection
         sign_in sponsor_user
         visit "/projects/#{project.id}"


### PR DESCRIPTION
Adds in the concept of no_ci