### PR TITLE
Removing Sidekiq line that is causing the servers to fail

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,5 +7,7 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
-  include Sidekiq::Job
+
+  # TODO: why does this cause the servers to break?
+  # include Sidekiq::Job
 end


### PR DESCRIPTION
```
App 652546 output: Error: The application encountered the following error: Sidekiq::Job cannot be included in an ActiveJob: ApplicationJob (ArgumentError)
App 652546 output:     /opt/tigerdata/shared/bundle/ruby/3.2.0/gems/sidekiq-7.2.1/lib/sidekiq/job.rb:159:in `included'
```