### PR TITLE
Newly created users must indicate CAS authentication 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,7 @@ class User < ApplicationRecord
       user.family_name = line["family_name"]
       user.display_name = line["display_name"]
       user.email = user.uid + "@princeton.edu"
+      user.provider = "cas"
       user.eligible_sponsor = line["eligible_sponsor"] == "TRUE"
       user.eligible_manager = line["eligible_manager"] == "TRUE"
       user.superuser = line["superuser"] == "TRUE"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,7 @@ class User < ApplicationRecord
       user.family_name = line["family_name"]
       user.display_name = line["display_name"]
       user.email = user.uid + "@princeton.edu"
+      # If we don't say that this is a cas user, they won't be able to log in with CAS
       user.provider = "cas"
       user.eligible_sponsor = line["eligible_sponsor"] == "TRUE"
       user.eligible_manager = line["eligible_manager"] == "TRUE"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe User, type: :model do
       User.load_registration_list
       expect(User.count).to eq 36
       user = User.find_by(uid: "mjc12")
+      # If we don't say that this is a cas user, they won't be able to log in with CAS
       expect(user.provider).to eq "cas"
     end
     it "updates a name if the name is updated in the spreadsheet" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -94,6 +94,8 @@ RSpec.describe User, type: :model do
       expect(User.count).to eq 1
       User.load_registration_list
       expect(User.count).to eq 36
+      user = User.find_by(uid: "mjc12")
+      expect(user.provider).to eq "cas"
     end
     it "updates a name if the name is updated in the spreadsheet" do
       User.load_registration_list


### PR DESCRIPTION
… or they won't be able to log in

Fixes #464 