### PR TITLE
Ensuring that superusers can create projects from the welcome dashboard

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,12 @@ class User < ApplicationRecord
   end
 
   def self.sponsor_users
-    User.where(eligible_sponsor: true).map(&:uid)
+    users = if Rails.env.development? || Rails.env.staging?
+              User.where(eligible_sponsor: true).or(User.where(superuser: true))
+            else
+              User.where(eligible_sponsor: true)
+            end
+    users.map(&:uid)
   end
 
   def clear_mediaflux_session(session)
@@ -65,6 +70,16 @@ class User < ApplicationRecord
     return uid if display_name.blank?
 
     display_name
+  end
+
+  def eligible_sponsor?
+    return true if superuser
+    super
+  end
+
+  def eligible_manager?
+    return true if superuser
+    super
   end
 
   def self.csv_data

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <div>
         <br/>
-        <%if current_user.eligible_sponsor?%>
+        <%if current_user.eligible_sponsor? || current_user.superuser? %>
           <%= link_to "New Project", new_project_path(), class: "btn btn-dark btn-sm" %>
         <%end%>
       </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <div>
         <br/>
-        <%if current_user.eligible_sponsor? || current_user.superuser? %>
+        <%if current_user.eligible_sponsor?%>
           <%= link_to "New Project", new_project_path(), class: "btn btn-dark btn-sm" %>
         <%end%>
       </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -141,4 +141,47 @@ RSpec.describe User, type: :model do
       expect(other_user.sysadmin).to be_falsey
     end
   end
+
+  describe "#eligible_sponsor?" do
+    it "should be true for a sponsor" do
+      user = FactoryBot.create(:project_sponsor)
+      expect(user).to be_eligible_sponsor
+    end
+
+    it "should be true for a superuser" do
+      user = FactoryBot.create(:superuser)
+      expect(user).to be_eligible_sponsor
+    end
+  end
+
+  describe "#eligible_manager?" do
+    it "should be true for a manager" do
+      user = FactoryBot.create(:project_manager)
+      expect(user).to be_eligible_manager
+    end
+
+    it "should be true for a superuser" do
+      user = FactoryBot.create(:superuser)
+      expect(user).to be_eligible_manager
+    end
+  end
+
+  describe "#sponsor_users" do
+    it "should only show sponsers" do
+      FactoryBot.create(:superuser)
+      project_sponsor = FactoryBot.create(:project_sponsor)
+      FactoryBot.create(:user)
+      expect(User.sponsor_users).to eq([project_sponsor.uid])
+    end
+
+    context "in development" do
+      it "should only show sponsers and superusers" do
+        superuser = FactoryBot.create(:superuser)
+        project_sponsor = FactoryBot.create(:project_sponsor)
+        FactoryBot.create(:user)
+        allow(Rails.env).to receive(:development?).and_return true
+        expect(User.sponsor_users).to eq([superuser.uid, project_sponsor.uid])
+      end
+    end
+  end
 end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -58,5 +58,17 @@ RSpec.describe "WelcomeController", stub_mediaflux: true do
         expect(page).not_to have_content "Sponsored by Me"
       end
     end
+
+    context "with the superuser role" do
+      let(:current_user) { FactoryBot.create(:superuser, uid: "pul123") }
+
+      it "shows the 'New Project' button" do
+        sign_in current_user
+        visit "/"
+        expect(page).to have_content("Welcome, #{current_user.given_name}!")
+        expect(page).not_to have_content "Please log in"
+        expect(page).to have_content "New Project"
+      end
+    end
   end
 end


### PR DESCRIPTION
By default, even with the `superuser` role, one still cannot create new projects.