### PR TITLE
changing the approve status from approve to active

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ApplicationRecord
 
   # TODO: What are the valid statuses?
   PENDING_STATUS = "pending"
-  APPROVE_STATUS = "approved"
+  APPROVE_STATUS = "active"
   delegate :to_json, to: :metadata_json
 
   def metadata


### PR DESCRIPTION
Changing `Project::APPROVE_STATUS` to `"active"` instead of `"approved"` as requested in #443 