### PR TITLE
Project Revision Request Confirmation Page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,12 +93,12 @@ class ProjectsController < ApplicationController
       metadata_params = project_params.merge({
         status: project.metadata[:status]
       })
-      project.metadata = project_metadata.update_metadata(params: metadata_params)
+      project.metadata = project_metadata.update_metadata(params: metadata_params) 
     end
     
     # @todo ProjectMetadata should be refactored to implement ProjectMetadata.valid?(updated_metadata)
     if project.save
-      redirect_to project
+      redirect_to project_revision_confirmation_path(@project)
     else
       render :edit
     end
@@ -109,6 +109,7 @@ class ProjectsController < ApplicationController
   end
 
   def confirmation; end
+  def revision_confirmation; end
 
   def contents
     project

--- a/app/views/projects/revision_confirmation.html.erb
+++ b/app/views/projects/revision_confirmation.html.erb
@@ -1,0 +1,14 @@
+  <div class="pending-project">
+  <h2> Project Revision Request Received </h2>
+
+    <p>Thank you for your submission.</p>
+
+    <p>Your request is in the queue. Please allow 5 business days for our team to review your needs and set everything up.</p>
+
+    <p>You can check up on your project status and make revisions at any time from your TigerData dashboard. 
+    
+    If you have questions, please contact the team at <%= mail_to "tigerdata@princeton.edu" %>.</p>
+
+  <%= button_to "Return to Dashboard", root_path, class: "btn btn-primary btn-sm", method: :get %>
+
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   get "projects/:id/confirmation", to: "projects#confirmation", as: :project_confirmation
   get "projects/:id/contents", to: "projects#contents", as: :project_contents
   get "projects/:id/list-contents", to: "projects#list_contents", as: :project_list_contents
+  get "projects/:id/revision_confirmation", to: "projects#revision_confirmation", as: :project_revision_confirmation
 
   namespace :api do
     namespace :v0 do

--- a/spec/system/project_roles_spec.rb
+++ b/spec/system/project_roles_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe "Project Edit Page Roles Validation", type: :system do
       fill_in "data_manager", with: new_data_manager.uid
       page.find("body").click
       click_on "Submit"
+      visit "/projects/#{project.id}"
       expect(page.find(:css, "#data_manager").text).to eq new_data_manager.display_name
     end
     it "does not allow anyone else to assign a Data Manager" do

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         expect(page.find("#non-editable-data-sponsor").text).to eq sponsor_user.uid
       end
 
-      it "redirects the user to the revision request confirmation page upon submission" do 
+      it "redirects the user to the revision request confirmation page upon submission" do
         click_on "Submit"
         project_in_mediaflux.reload
         expect(project_in_mediaflux.metadata[:directory]).to eq "project-123"

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         expect(page).to have_content("Pending projects can not be edited.")
       end
     end
+
     context "a project is active" do
       it "redirects the user to the project details page if the user is not a sponsor or manager" do
         sign_in read_only
@@ -121,13 +122,31 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         project_in_mediaflux.save!
         visit "/projects/#{project_in_mediaflux.id}/edit"
       end
+
       it "preserves the readonly directory field" do
         click_on "Submit"
         project_in_mediaflux.reload
         expect(project_in_mediaflux.metadata[:directory]).to eq "project-123"
       end
+
       it "loads existing Data Sponsor" do
         expect(page.find("#non-editable-data-sponsor").text).to eq sponsor_user.uid
+      end
+
+      it "redirects the user to the revision request confirmation page upon submission" do 
+        click_on "Submit"
+        project_in_mediaflux.reload
+        expect(project_in_mediaflux.metadata[:directory]).to eq "project-123"
+
+        # This is the confirmation page. It needs a button to return to the dashboard
+        # and it needs to be_axe_clean.
+        expect(page).to have_content "Project Revision Request Received"
+        expect(page).to have_button "Return to Dashboard"
+        expect(page).to be_axe_clean
+          .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)
+          .skipping(:'color-contrast')
+        click_on "Return to Dashboard"
+        expect(page).to have_content "Sponsored by Me"
       end
     end
   end


### PR DESCRIPTION
created a confirmation page for project revision requests
tested the route and display of the page
made it so that submitting the edit form redirects the user to the revision confirmation page modified the project roles spec to visit the project since the edit submission no longer redirects the user back to the project

Closes #277 