### PR TITLE
Tigerdata Schema: make description an optional field

### DIFF
--- a/app/models/tigerdata_schema.rb
+++ b/app/models/tigerdata_schema.rb
@@ -67,7 +67,7 @@ class TigerdataSchema
     # WARNING: Do not use `id` as field name, MediaFlux uses specific rules for an `id` field.
     code = { name: "code", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "The unique identifier for the project" }
     title = { name: "title", type: "string", index: false, "min-occurs" => 1, "max-occurs" => 1, label: "A plain-language title for the project" }
-    description = { name: "description", type: "string", index: false, "min-occurs" => 1, "max-occurs" => 1, label: "A brief description of the project" }
+    description = { name: "description", type: "string", index: false, "min-occurs" => 0, "max-occurs" => 1, label: "A brief description of the project" }
     status = { name: "status", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "The current status of the project" }
     data_sponsor = { name: "data_sponsor", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "The person who takes primary responsibility for the project" }
     data_manager = { name: "data_manager", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "The person who manages the day-to-day activities for the project" }

--- a/spec/models/tigerdata_schema_spec.rb
+++ b/spec/models/tigerdata_schema_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TigerdataSchema, type: :model do
         "asset.doc.type.update :create true :description \"Project metadata\" :type tigerdata:project :definition < \\\n" \
         " :element -name code -type string -index true -min-occurs 1 -max-occurs 1 -label \"The unique identifier for the project\" \\\n" \
         " :element -name title -type string -min-occurs 1 -max-occurs 1 -label \"A plain-language title for the project\" \\\n" \
-        " :element -name description -type string -min-occurs 1 -max-occurs 1 -label \"A brief description of the project\" \\\n" \
+        " :element -name description -type string -min-occurs 0 -max-occurs 1 -label \"A brief description of the project\" \\\n" \
         " :element -name status -type string -index true -min-occurs 1 -max-occurs 1 -label \"The current status of the project\" \\\n" \
         " :element -name data_sponsor -type string -index true -min-occurs 1 -max-occurs 1 -label \"The person who takes primary responsibility for the project\" \\\n" \
         " :element -name data_manager -type string -index true -min-occurs 1 -max-occurs 1 -label \"The person who manages the day-to-day activities for the project\" \\\n" \


### PR DESCRIPTION
updated the tigerdata schema to make the description optional
updated the spec that generates the aterm command to create the schema
closes: #410 