### PR TITLE
Restructuring the TigerdataMailer parameters in order to utilize Project IDs

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,7 +20,9 @@ class ProjectsController < ApplicationController
     })
     project_metadata.create(params: metadata_params)
     if new_project.save
-      TigerdataMailer.with(project: @project).project_creation.deliver_later
+      mailer = TigerdataMailer.with(project_id: @project.id)
+      mailer.project_creation.deliver_later
+
       redirect_to project_confirmation_path(@project)
     else
       render :new

--- a/spec/mailers/tigerdata_spec.rb
+++ b/spec/mailers/tigerdata_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 
 RSpec.describe TigerdataMailer, type: :mailer do
   let(:project) { FactoryBot.create :project, project_id: "abc123/def" }
+  let(:project_id) { project.id }
 
   it "Sends project creation reuests" do
-    expect { described_class.with(project: project).project_creation.deliver }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { described_class.with(project_id:).project_creation.deliver }.to change { ActionMailer::Base.deliveries.count }.by(1)
     mail = ActionMailer::Base.deliveries.last
 
     expect(mail.subject).to eq "Project Creation Request"
@@ -23,11 +24,20 @@ RSpec.describe TigerdataMailer, type: :mailer do
     expect(mail.attachments.count).to be_positive
     # testing the json response
     expect(mail.attachments.first.filename).to eq "abc123_def.json"
-    expect(mail.attachments.first.body.raw_source).to eq project.metadata.to_json
+    parsed_body = JSON.parse(mail.attachments.first.body.raw_source)
+    expect(parsed_body).to eq project.metadata
     expect(mail.attachments.first.mime_type).to eq "application/json"
     # testing the xml response
     expect(mail.attachments.second.filename).to eq "abc123_def.xml"
     expect(mail.attachments.second.body.raw_source).to eq project.to_xml.gsub("\n", "\r\n")
     expect(mail.attachments.second.mime_type).to eq "application/xml"
+  end
+
+  context "when the project ID is invalid or nil" do
+    let(:project_id) { "invalid" }
+
+    it "does not enqueue an e-mail message and raises an error" do
+      expect { described_class.with(project_id:).project_creation.deliver }.to raise_error(ArgumentError, "Invalid Project ID provided for the TigerdataMailer: #{project_id}")
+    end
   end
 end


### PR DESCRIPTION
Restructuring the TigerdataMailer parameters in order to utilize Project IDs (this avoids errors within Sidekiq worker processing). Resolves #476 