### PR TITLE
Implements feature show more/less files 

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -85,7 +85,7 @@ class ProjectsController < ApplicationController
       project.metadata_json["status"] = Project::APPROVE_STATUS
       params.delete("mediaflux_id")
     end
-    
+
     #Edit action
     if params.key?("title")
       project_metadata = ProjectMetadata.new(project: project, current_user:)
@@ -95,7 +95,7 @@ class ProjectsController < ApplicationController
       })
       project.metadata = project_metadata.update_metadata(params: metadata_params)
     end
-    
+
     # @todo ProjectMetadata should be refactored to implement ProjectMetadata.valid?(updated_metadata)
     if project.save
       redirect_to project
@@ -113,7 +113,7 @@ class ProjectsController < ApplicationController
   def contents
     project
     @num_files = project.asset_count(session_id: current_user.mediaflux_session)
-    @file_list = project.file_list(session_id: current_user.mediaflux_session, size: 20)
+    @file_list = project.file_list(session_id: current_user.mediaflux_session, size: 100)
     @file_list[:files].sort_by!(&:path)
   end
 

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -148,16 +148,12 @@ function initListContentsModal() {
 function showMoreLessContent() {
   $("#show-more").on("click", function(el) {
     if (el.target.textContent == "Show More") {
-      $("#file-list>tbody>tr").removeClass("invisible-row");
+      $("#file-list>tbody>tr.bottom-section").removeClass("invisible-row");
       el.target.textContent = "Show Less";
     } else {
       // Show less
-      // The formula -n+12 show the first 11 rows (header + 10 file names)
-      // See https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
-      $("#file-list>tbody>tr").addClass("invisible-row");
-      $("#file-list>tbody>tr:nth-child(-n+12)").removeClass("invisible-row");
+      $("#file-list>tbody>tr.bottom-section").addClass("invisible-row");
       el.target.textContent = "Show More";
-
       // Source: https://stackoverflow.com/a/10681265/446681
       $(window).scrollTop(0);
     }

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -145,6 +145,26 @@ function initListContentsModal() {
   }
 }
 
+function showMoreLessContent() {
+  $("#show-more").on("click", function(el) {
+    if (el.target.textContent == "Show More") {
+      $("#file-list>tbody>tr").removeClass("invisible-row");
+      el.target.textContent = "Show Less";
+    } else {
+      // Show less
+      // The formula -n+12 show the first 11 rows (header + 10 file names)
+      // See https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
+      $("#file-list>tbody>tr").addClass("invisible-row");
+      $("#file-list>tbody>tr:nth-child(-n+12)").removeClass("invisible-row");
+      el.target.textContent = "Show More";
+
+      // Source: https://stackoverflow.com/a/10681265/446681
+      $(window).scrollTop(0);
+    }
+    el.preventDefault();
+  });
+}
+
 function initPage() {
   $('#test-jquery').click((event) => {
     setTargetHtml(event, 'jQuery works!');
@@ -153,6 +173,7 @@ function initPage() {
   datalist.setupDatalistValidity();
   initDataUsers();
   initListContentsModal();
+  showMoreLessContent();
 }
 
 window.addEventListener('load', () => initPage());

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -146,14 +146,15 @@ function initListContentsModal() {
 }
 
 function showMoreLessContent() {
-  $("#show-more").on("click", function(el) {
-    if (el.target.textContent == "Show More") {
-      $("#file-list>tbody>tr.bottom-section").removeClass("invisible-row");
-      el.target.textContent = "Show Less";
+  $('#show-more').on('click', (el) => {
+    const element = el;
+    if (el.target.textContent === 'Show More') {
+      $('#file-list>tbody>tr.bottom-section').removeClass('invisible-row');
+      element.target.textContent = 'Show Less';
     } else {
       // Show less
-      $("#file-list>tbody>tr.bottom-section").addClass("invisible-row");
-      el.target.textContent = "Show More";
+      $('#file-list>tbody>tr.bottom-section').addClass('invisible-row');
+      element.target.textContent = 'Show More';
       // Source: https://stackoverflow.com/a/10681265/446681
       $(window).scrollTop(0);
     }

--- a/app/models/mediaflux/asset.rb
+++ b/app/models/mediaflux/asset.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Mediaflux
   class Asset
-    attr_accessor :id, :name, :path, :collection, :size
+    attr_accessor :id, :path, :collection, :size
 
     def initialize(id:, name:, collection:, path: nil, last_modified_mf: nil, size: nil)
       @id = id
@@ -10,6 +10,17 @@ module Mediaflux
       @collection = collection
       @size = size
       @last_modified_mf = last_modified_mf
+    end
+
+    def name
+      # Mediaflux supports the concept of files without a name and in those cases the
+      # "name" property might be empty, but the actual name assigned internally by
+      # Mediaflux (e.g. __asset_id__4665) is still reflected in the path.
+      if @name == ""
+        Pathname.new(path).basename.to_s
+      else
+        @name
+      end
     end
 
     # Returns the path to the asset but without the root namespace as part of it.

--- a/app/views/projects/contents.html.erb
+++ b/app/views/projects/contents.html.erb
@@ -11,6 +11,14 @@
   .numeric_column {
     text-align: right;
   }
+
+  .visible-row {
+    visibility: unset;
+  }
+
+  .invisible-row {
+    visibility: collapse;
+  }
 </style>
 <content id= "content">
   <h1>Project Contents</h1>
@@ -31,7 +39,9 @@
           <th class="numeric_column">Last modified</th>
         </tr>
         <% current_folder = nil %>
-        <% @file_list[:files].each do |file| %>
+        <% @file_list[:files].each_with_index do |file, index| %>
+
+          <% @css_visible = index < 10 ? "visible-row" : "invisible-row" %>
 
           <% if current_folder != file.path_only %>
             <!--
@@ -40,7 +50,7 @@
               collection record first or a _file_ under the collection first.
             -->
             <% current_folder = file.path_only %>
-            <tr>
+            <tr class="<%= @css_visible %>">
               <td><b><%= current_folder %>/</b></td>
               <td>&nbsp;</td>
               <td>&nbsp;</td>
@@ -50,7 +60,7 @@
 
           <% unless file.collection %>
             <!-- Print the file information row -->
-            <tr>
+            <tr class="<%= @css_visible %>">
               <td>&nbsp;</td>
               <td><%= file.name %> </td>
               <td class="numeric_column"><%= number_to_human_size(file.size) %></td>
@@ -61,7 +71,7 @@
       </table>
     </div>
     <form name="project-contents-preview">
-      <button type="button" class="btn btn-primary">Show More</button>
+      <button id="show-more" type="button" class="btn btn-primary">Show More</button>
       <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#list-contents-modal">List All Files</button>
       <button type="button" class="btn btn-dark">Custom Query</button>
     </form>

--- a/app/views/projects/contents.html.erb
+++ b/app/views/projects/contents.html.erb
@@ -41,7 +41,7 @@
         <% current_folder = nil %>
         <% @file_list[:files].each_with_index do |file, index| %>
 
-          <% @css_visible = index < 10 ? "visible-row" : "invisible-row" %>
+          <% @row_css = index < 10 ? "visible-row top-section" : "invisible-row bottom-section" %>
 
           <% if current_folder != file.path_only %>
             <!--
@@ -50,7 +50,7 @@
               collection record first or a _file_ under the collection first.
             -->
             <% current_folder = file.path_only %>
-            <tr class="<%= @css_visible %>">
+            <tr class="<%= @row_css %>">
               <td><b><%= current_folder %>/</b></td>
               <td>&nbsp;</td>
               <td>&nbsp;</td>
@@ -60,7 +60,7 @@
 
           <% unless file.collection %>
             <!-- Print the file information row -->
-            <tr class="<%= @css_visible %>">
+            <tr class="<%= @row_css %>">
               <td>&nbsp;</td>
               <td><%= file.name %> </td>
               <td class="numeric_column"><%= number_to_human_size(file.size) %></td>

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
     context "Project Contents" do
       let(:project) { FactoryBot.create(:project, project_id: "jh34", data_sponsor: sponsor_user.uid, directory: FFaker::Food.ingredient.underscore) }
       let(:file_list) { project.file_list(session_id: sponsor_user.mediaflux_session, size: 100)[:files].sort_by!(&:path) }
-      let(:files_only_list) { file_list.select { |asset| asset.collection == false } }
-      let(:dirs_only_list) { file_list.select { |asset| asset.collection == true } }
+      let(:first_file) { file_list.select { |asset| asset.collection == false }.first }
+      let(:second_file) { file_list.select { |asset| asset.collection == false }.second }
+      let(:last_file) { file_list.select { |asset| asset.collection == false }.last }
 
       before do
         @original_api_host = Rails.configuration.mediaflux["api_host"]
@@ -125,9 +126,14 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
         expect(page).to have_selector(:link_or_button, "Review Contents")
         click_on("Review Contents")
 
-        # Files and directories are displayed
-        expect(page).to have_content(files_only_list[0].name)
-        expect(page).to have_content(files_only_list[1].name)
+        # Files are displayed
+        expect(page).to have_content(first_file.name)
+        expect(page).to have_content(second_file.name)
+        expect(page).not_to have_content(last_file.name)
+
+        # More files are displayed
+        click_on("Show More")
+        expect(page).to have_content(last_file.name)
       end
     end
 


### PR DESCRIPTION
Allows the user to view more (or less) files from the Mediaflux backend for the current project.

## Initial display
![Screenshot 2024-02-21 at 10 18 23 AM](https://github.com/pulibrary/tiger-data-app/assets/568286/13060df2-ffe5-44da-8c82-39706eca35c0)

## After Show more
![Screenshot 2024-02-21 at 10 18 31 AM](https://github.com/pulibrary/tiger-data-app/assets/568286/6b104cf1-c9af-450b-a504-e802c953668d)

Closes #390 
