### PR TITLE
Handle Redis client errors within ProjectsController#create

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,12 +21,18 @@ class ProjectsController < ApplicationController
     project_metadata.create(params: metadata_params)
     if new_project.save
       mailer = TigerdataMailer.with(project_id: @project.id)
-      mailer.project_creation.deliver_later
+      message_delivery = mailer.project_creation
+      message_delivery.deliver_later
 
       redirect_to project_confirmation_path(@project)
     else
       render :new
     end
+  rescue RedisClient::CannotConnectError => redis_connect_error
+    error_message = "Failed to connect to Redis: #{redis_connect_error}"
+    Rails.logger.error(error_message)
+    flash[:notice] = error_message
+    render :new
   end
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -29,10 +29,10 @@ class ProjectsController < ApplicationController
       render :new
     end
   rescue RedisClient::CannotConnectError => redis_connect_error
-    error_message = "Failed to connect to Redis: #{redis_connect_error}"
+    error_message = "We are sorry, while the project was successfully created, an error was encountered which prevents the delivery of an e-mail message confirming this. Please know that this error has been logged, and shall be reviewed by members of RDSS."
 
     Rails.logger.error(error_message)
-    Honeybadger.notify(redis_connect_error, context: { project_id: @project.id })
+    Honeybadger.notify(redis_connect_error, context: { current_user_email: current_user.email, project_id: @project.id })
 
     flash[:notice] = error_message
     render :new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,7 +30,10 @@ class ProjectsController < ApplicationController
     end
   rescue RedisClient::CannotConnectError => redis_connect_error
     error_message = "Failed to connect to Redis: #{redis_connect_error}"
+
     Rails.logger.error(error_message)
+    Honeybadger.notify(redis_connect_error, context: { project_id: @project.id })
+
     flash[:notice] = error_message
     render :new
   end

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -357,6 +357,47 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         expect(project.mediaflux_id).not_to be_nil
       end
     end
+
+    context "when an error is encountered while trying to enqueue the ActiveJob for the TigerdataMailer" do
+      let(:mailer) { double(ActionMailer::Parameterized::Mailer) }
+      let(:message_delivery) { instance_double(ActionMailer::Parameterized::MessageDelivery) }
+      let(:error_message) { "Connection refused - connect(2) for 127.0.0.1:6379" }
+
+      before do
+        allow(message_delivery).to receive(:deliver_later).and_raise(RedisClient::CannotConnectError, error_message)
+        allow(mailer).to receive(:project_creation).and_return(message_delivery)
+        allow(TigerdataMailer).to receive(:with).and_return(mailer)
+      end
+
+      it "logs the error message, flashes a notification to the end-user, and renders the New Project View" do
+        sign_in sponsor_user
+        visit "/"
+        click_on "New Project"
+        expect(page.find("#non-editable-data-sponsor").text).to eq sponsor_user.uid
+        fill_in "data_manager", with: data_manager.uid
+        fill_in "ro-user-uid-to-add", with: read_only.uid
+        # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+        page.find("body").click
+        click_on "btn-add-ro-user"
+        fill_in "rw-user-uid-to-add", with: read_write.uid
+        # Without removing the focus from the form field, the "change" event is not propagated for the DOM
+        page.find("body").click
+        click_on "btn-add-rw-user"
+        select "RDSS", from: 'departments'
+        fill_in "directory", with: FFaker::Name.name.gsub(" ","_")
+        fill_in "title", with: "My test project"
+        expect(page).to have_content("Project Directory: /td-test-001/")
+        expect(page.find_all("input:invalid").count).to eq(0)
+        click_on "Submit"
+        # For some reason the above click on submit sometimes does not submit the form
+        #  even though the inputs are all valid, so try it again...
+        if page.find_all("#btn-add-rw-user").count > 0
+          click_on "Submit"
+        end
+        expect(page).not_to have_content "New Project Request Received"
+        expect(page).to have_content error_message
+      end
+    end
   end
 
   context "Index page" do

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -362,6 +362,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       let(:mailer) { double(ActionMailer::Parameterized::Mailer) }
       let(:message_delivery) { instance_double(ActionMailer::Parameterized::MessageDelivery) }
       let(:error_message) { "Connection refused - connect(2) for 127.0.0.1:6379" }
+      let(:flash_message) { "We are sorry, while the project was successfully created, an error was encountered which prevents the delivery of an e-mail message confirming this. Please know that this error has been logged, and shall be reviewed by members of RDSS." }
 
       before do
         allow(Honeybadger).to receive(:notify)
@@ -396,11 +397,11 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
           click_on "Submit"
         end
         expect(page).not_to have_content "New Project Request Received"
-        expect(page).to have_content error_message
+        expect(page).to have_content flash_message
 
         new_project = Project.last
         expect(new_project).not_to be nil
-        expect(Honeybadger).to have_received(:notify).with(kind_of(RedisClient::CannotConnectError), context: { project_id: new_project.id })
+        expect(Honeybadger).to have_received(:notify).with(kind_of(RedisClient::CannotConnectError), context: { current_user_email: sponsor_user.email, project_id: new_project.id })
       end
     end
   end


### PR DESCRIPTION
Ensuring that ProjectsController#create actions which encounter Redis client connection errors log these for Rails, flash a warning for end-users, and render the New Project View. This resolves #477 