### PR TITLE
Save export files to a shared location

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -136,14 +136,15 @@ class ProjectsController < ApplicationController
   end
 
   def list_contents
-    Rails.logger.error("entered controller")
-
     project_job_service.list_contents_job(user: current_user)
 
     json_response = {
       message: "File list for \"#{project.title}\" is being generated in the background."
     }
     render json: json_response
+  rescue => ex
+    Rails.logger.error("Error producing document list (project id: #{project&.id}): #{ex.message}")
+    render json: { message: "Document list could not be generated." }
   end
 
   def file_list_download

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -136,6 +136,8 @@ class ProjectsController < ApplicationController
   end
 
   def list_contents
+    Rails.logger.error("entered controller")
+
     project_job_service.list_contents_job(user: current_user)
 
     json_response = {

--- a/app/jobs/list_project_contents_job.rb
+++ b/app/jobs/list_project_contents_job.rb
@@ -7,7 +7,10 @@ class ListProjectContentsJob < ApplicationJob
     raise "Invalid user id #{user_id} for job #{job_id}" if user.nil?
 
     # Queries Mediaflux for the file list and saves it to a CSV file.
-    project.file_list_to_file(session_id: mediaflux_session, filename: filename_for_export)
+    filename = filename_for_export
+    Rails.logger.info "Exporting file list to #{filename} for project #{project_id}"
+    project.file_list_to_file(session_id: mediaflux_session, filename: filename)
+    Rails.logger.info "Export file generated #{filename} for project #{project_id}"
 
     mark_user_job_as_complete(project: project, user: user)
   end

--- a/app/jobs/list_project_contents_job.rb
+++ b/app/jobs/list_project_contents_job.rb
@@ -5,10 +5,9 @@ class ListProjectContentsJob < ApplicationJob
     raise "Invalid project id #{project_id} for job #{job_id}" if project.nil?
     user = User.find(user_id)
     raise "Invalid user id #{user_id} for job #{job_id}" if user.nil?
-    filename = filename_for_export
 
     # Queries Mediaflux for the file list and saves it to a CSV file.
-    project.file_list_to_file(session_id: mediaflux_session, filename: filename)
+    project.file_list_to_file(session_id: mediaflux_session, filename: filename_for_export)
 
     mark_user_job_as_complete(project: project, user: user)
   end
@@ -21,12 +20,10 @@ class ListProjectContentsJob < ApplicationJob
       logon_request.session_token
     end
 
-    # TODO: This only works with one server. In a multi-server environment
-    # there is no guarantee that the client will be able to fetch the file
-    # since requests could go to any of the many servers.
-    # See https://github.com/pulibrary/tiger-data-app/issues/523
     def filename_for_export
-      "#{Dir.pwd}/public/#{job_id}.csv"
+      raise "Shared location is not configured" if Rails.configuration.mediaflux["shared_files_location"].blank?
+      pathname = Pathname.new(Rails.configuration.mediaflux["shared_files_location"])
+      pathname.join("#{job_id}.csv").to_s
     end
 
     def mark_user_job_as_complete(project:, user:)

--- a/app/services/project_job_service.rb
+++ b/app/services/project_job_service.rb
@@ -7,6 +7,7 @@ class ProjectJobService
 
   def list_contents_job(user:)
     job = ListProjectContentsJob.perform_later(user_id: user.id, project_id: @project.id)
+    Rails.logger.error("Job scheduled, job id: #{job.job_id}, (Sidekiq JID: #{job.provider_job_id}")
     UserJob.create_and_link_to_user(job_id: job.job_id, user: user, job_title: "File list for #{@project.title}")
   end
 end

--- a/app/services/project_job_service.rb
+++ b/app/services/project_job_service.rb
@@ -7,7 +7,9 @@ class ProjectJobService
 
   def list_contents_job(user:)
     job = ListProjectContentsJob.perform_later(user_id: user.id, project_id: @project.id)
-    Rails.logger.error("Job scheduled, job id: #{job.job_id}, (Sidekiq JID: #{job.provider_job_id}")
+    # Log the job id and the Sidekiq JID in case we need to troubleshoot the job
+    # https://github.com/sidekiq/sidekiq/wiki/Active-Job#job-id
+    Rails.logger.info("Job scheduled, job id: #{job.job_id}, (Sidekiq JID: #{job.provider_job_id || 'nil'})")
     UserJob.create_and_link_to_user(job_id: job.job_id, user: user, job_title: "File list for #{@project.title}")
   end
 end

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -10,6 +10,7 @@ production:
   api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] %>
   api_user: <%= ENV["MEDIAFLUX_USER"] %>
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
+  shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || '/mnt/nfs/tigerdata' %>
 qa:
   api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-qa-001/tigerdataNS' %>
   api_root_collection_name: 'tigerdata'
@@ -21,6 +22,7 @@ qa:
   api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] %>
   api_user: <%= ENV["MEDIAFLUX_USER"] %>
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
+  shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || '/mnt/nfs/tigerdata' %>
 staging:
   api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-staging-001/tigerdataNS'  %>
   api_root_collection_name: 'tigerdata'
@@ -32,6 +34,7 @@ staging:
   api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] %>
   api_user: <%= ENV["MEDIAFLUX_USER"] %>
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
+  shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || '/mnt/nfs/tigerdata' %>
 development:
   api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-demo-001/tigerdataNS' %>
   api_root_collection_name: 'tigerdata'
@@ -43,6 +46,7 @@ development:
   api_domain: <%= ENV["MEDIAFLUX_DOMAIN"] || 'system' %>
   api_user: <%= ENV["MEDIAFLUX_USER"] || 'manager' %>
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] || 'change_me' %>
+  shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || './public/' %>
 test:
   api_root_ns: '/td-test-001/tigerdataNS'
   api_root_collection_name: 'tigerdata'
@@ -54,3 +58,4 @@ test:
   api_domain: 'system'
   api_user: 'manager'
   api_password: 'change_me'
+  shared_files_location: './public/'

--- a/lib/tasks/exports.rake
+++ b/lib/tasks/exports.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+namespace :exports do
+  desc "Outputs to the console a list of export files and an indication of whether they are too old"
+  task :report_old, [:days] => [:environment] do |_, args|
+    days = (args[:days] || "30").to_i
+    pathname = Pathname.new(Rails.configuration.mediaflux["shared_files_location"])
+    scan_directory(pathname.join("*.csv")).each do |file|
+      puts "#{file[:name]}, #{file[:age]}, #{file[:age] > days}"
+    end
+  end
+
+  desc "Deletes files that are too old (default to 30 days)"
+  task :delete_old, [:days] => [:environment] do |_, args|
+    days = (args[:days] || "30").to_i
+    pathname = Pathname.new(Rails.configuration.mediaflux["shared_files_location"])
+    scan_directory(pathname.join("*.csv")).each do |file|
+      if file[:age] > days
+        File.delete(file[:name])
+      end
+    end
+  end
+
+  private
+
+    def scan_directory(path)
+      files = []
+      Dir[path].each do |filename|
+        file_info = File.stat(filename)
+        age_in_seconds = Time.zone.now - file_info.mtime
+        age_in_days = (age_in_seconds / (60 * 60 * 24)).round
+        files << { name: filename, age: age_in_days }
+      end
+      files
+    end
+end

--- a/spec/jobs/list_project_contents_job_spec.rb
+++ b/spec/jobs/list_project_contents_job_spec.rb
@@ -39,11 +39,10 @@ RSpec.describe ListProjectContentsJob, stub_mediaflux: true do
       expect(user_job.completed_at).to_not be nil
     end
 
-    # TODO: Update this test once https://github.com/pulibrary/tiger-data-app/issues/523
-    # has been implemented
     it "saves the output to a file" do
       job = described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
-      expect(File.exist?("#{Dir.pwd}/public/#{job.job_id}.csv")).to be true
+      output_file = Pathname.new(Rails.configuration.mediaflux["shared_files_location"]).join("#{job.job_id}.csv").to_s
+      expect(File.exist?(output_file)).to be true
     end
 
     context "when an invalid User ID is specified" do


### PR DESCRIPTION
Save export files to our shared location so that can be fetched regardless of what server ran the job originally.

Also added a sample rake task to delete old files from shared location (say after 30 days). We could schedule this task to run on schedule (see issue #542):

To view a list of export files:
```
bundle exec rake exports:report_old
```

To delete old export files:
```
bundle exec rake exports:delete_old
```

Closes #523 