### PR TITLE
User Job Timestamps

### DIFF
--- a/app/models/user_job.rb
+++ b/app/models/user_job.rb
@@ -6,11 +6,11 @@ class UserJob < ApplicationRecord
   end
 
   def description
-    "Requested #{created_at.in_time_zone("America/New_York").iso8601}"
+    "Requested #{created_at.in_time_zone('America/New_York').iso8601}"
   end
 
   def completion
-    "Completed #{completed_at.in_time_zone("America/New_York").iso8601}"
+    "Completed #{completed_at.in_time_zone('America/New_York').iso8601}"
   end
 
   def complete?

--- a/app/models/user_job.rb
+++ b/app/models/user_job.rb
@@ -6,11 +6,11 @@ class UserJob < ApplicationRecord
   end
 
   def description
-    "Requested #{created_datestamp}"
+    "Requested #{created_at.in_time_zone("America/New_York").iso8601}"
   end
 
   def completion
-    "Completed #{completed_at}"
+    "Completed #{completed_at.in_time_zone("America/New_York").iso8601}"
   end
 
   def complete?


### PR DESCRIPTION
fixed the bug that was causing the app to break when a user request a file inventory for a project                                                                                                                                                converted user job timestamps to america/new your and iso format