### PR TITLE
Do not install ddtrace in test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ commands:
           key: &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
       - run: bundle config set path './vendor/bundle'
       - run: bundle config set --local without production
+      - run: gem uninstall ddtrace -a -x
       - run: bundle install --jobs=4 --retry=3
       - save_cache:
           key: *gem_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ commands:
       - restore_cache:
           key: &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
       - run: bundle config set path './vendor/bundle'
+      - run: bundle config set --local without production
       - run: bundle install --jobs=4 --retry=3
       - save_cache:
           key: *gem_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ commands:
           key: &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
       - run: bundle config set path './vendor/bundle'
       - run: bundle config set --local without production
-      - run: gem uninstall ddtrace -a -x
       - run: bundle install --jobs=4 --retry=3
       - save_cache:
           key: *gem_key

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem "devise"
 gem "omniauth-cas"
 
 gem "datacite", github: "sul-dlss/datacite-ruby", branch: "main"
-gem "ddtrace", require: "ddtrace/auto_instrument"
 gem "dogstatsd-ruby"
 gem "google-protobuf", "~> 3.0"
 gem "health-monitor-rails"
@@ -65,6 +64,10 @@ gem "honeybadger"
 gem "mailcatcher"
 gem "net-http-persistent"
 gem "sidekiq"
+
+group :staging, :production do
+  gem "ddtrace", require: "ddtrace/auto_instrument"
+end
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,9 +4,9 @@ require_relative "boot"
 require "rails/all"
 require_relative "lando_env"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+# Require the gems listed in Gemfile, but only the default ones
+# and those for the environment rails is running in
+Bundler.require(:default, Rails.env)
 
 module TigerDataApp
   class Application < Rails::Application

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -8,7 +8,7 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.service = "tigerdata"
   c.version = "1.0.0"
-  c.profiling.enabled = true
+  c.profiling.enabled = Rails.env.staging? || Rails.env.production?
 
   c.tracing.report_hostname = true
   c.tracing.analytics.enabled = true


### PR DESCRIPTION
* Only install default + Rails.env gems; Previously we were installing all gems in all environments
* Disable ddtrace in test and development (this eliminates error messages in our rspec run)