### PR TITLE
Tigerdata Storage Usage for Projectg in qa

### DIFF
--- a/app/models/mediaflux/http/get_metadata_request.rb
+++ b/app/models/mediaflux/http/get_metadata_request.rb
@@ -26,6 +26,7 @@ module Mediaflux
 
         if metadata[:collection]
           metadata[:total_file_count] = asset.xpath("./collection/accumulator/value/non-collections").text
+          metadata[:size] = asset.xpath("./collection/accumulator/value/total/@h").text
         end
 
         parse_image(asset.xpath("./meta/mf-image"), metadata) # this does not do anything because mf-image is not a part of the meta xpath
@@ -65,8 +66,6 @@ module Mediaflux
             collection: asset.xpath("./@collection")&.text == "true",
             path: asset.xpath("./path").text,
             type: asset.xpath("./type").text,
-            size: asset.xpath("./content/size").text,
-            size_human: asset.xpath("./content/size/@h").text,
             namespace: asset.xpath("./namespace").text,
             accumulators: asset.xpath("./collection/accumulator/value") # list of accumulator values in xml format. Can parse further through xpath
           }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -109,10 +109,13 @@ class Project < ApplicationRecord
     return unless in_mediaflux?
 
     values = mediaflux_metadata(session_id:)
-    value = values[:size_human]
-
-    return self.class.default_storage_usage if value.blank?
-    value
+    value = values.fetch(:size, 0)
+    
+    if value.blank?
+      return self.class.default_storage_usage
+    else
+      return value
+    end
   end
 
   def self.default_storage_capacity

--- a/spec/fixtures/files/collection_asset_get_response.xml
+++ b/spec/fixtures/files/collection_asset_get_response.xml
@@ -11,10 +11,10 @@
           <domain>system</domain>
           <user>manager</user>
         </creator>
-        <ctime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1680811888032">06-Apr-2023 20:11:28</ctime>
-        <vmtime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1680811888032">06-Apr-2023 20:11:28</vmtime>
-        <mtime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1680811888032">06-Apr-2023 20:11:28</mtime>
-        <stime>1517</stime>
+        <ctime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1706555079069">29-Jan-2024 19:04:39</ctime>
+        <vmtime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1706555079069">29-Jan-2024 19:04:39</vmtime>
+        <mtime tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1706555079069">29-Jan-2024 19:04:39</mtime>
+        <stime>31055195</stime>
         <created-via secure="false">http</created-via>
         <versioned count="1">true</versioned>
         <access>
@@ -37,7 +37,7 @@
           <access-asset-content>true</access-asset-content>
           <modify-asset-content>true</modify-asset-content>
         </access>
-        <meta stime="1516">
+        <meta stime="1952">
           <mf-revision-history id="1">
             <user id="15">
               <domain>system</domain>
@@ -45,13 +45,40 @@
             </user>
             <type>create</type>
           </mf-revision-history>
+          <tigerdata:project xmlns:tigerdata="tigerdata" id="2">
+            <code>Oblivion</code>
+            <title>Oblivion</title>
+            <description>Testing</description>
+            <status>pending</status>
+            <data_sponsor>jh6441</data_sponsor>
+            <data_manager>bs3097</data_manager>
+            <departments>RDSS</departments>
+            <created_on>29-Jan-2024 14:04:18</created_on>
+            <created_by>jh6441</created_by>
+            <project_id>10.34770/tbd</project_id>
+            <storage_capacity>500 GB</storage_capacity>
+            <storage_performance>Standard</storage_performance>
+            <project_purpose>Research</project_purpose>
+          </tigerdata:project>
         </meta>
         <collection>
-          <leaf>true</leaf>
           <unique-name-index>true</unique-name-index>
-          <store inherited="true">data</store>
-          <contained-asset-index cascade="false">true</contained-asset-index>
-          <member-change-time tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1680868762565">07-Apr-2023 11:59:22</member-change-time>
+          <store inherited="true">db</store>
+          <contained-asset-index cascade="true">true</contained-asset-index>
+          <member-change-time tz="Etc/UTC" gmt-offset="0.0" dst="false" millisec="1707076006057">04-Feb-2024 19:46:46</member-change-time>
+          <accumulator type="collection.asset.count" name="number of assets">
+            <stime>31058435</stime>
+            <value>
+              <collections>25</collections>
+              <non-collections>60</non-collections>
+            </value>
+          </accumulator>
+          <accumulator type="content.all.size" name="total storage">
+            <stime>31058435</stime>
+            <value>
+              <total count="60" count-zero="0" h="6 KB">6000</total>
+            </value>
+          </accumulator>
         </collection>
         <members>
           <static>1</static>

--- a/spec/models/mediaflux/http/get_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/get_metadata_request_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
       expect(metadata[:collection]).to be_falsey
       expect(metadata[:path]).to eq("/td-test-001/collection-96-55948/file-96-57045")
       expect(metadata[:type]).to eq("content/unknown")
+      expect(metadata[:size]).to be nil
       expect(WebMock).to have_requested(:post, mediflux_url)
     end
 
@@ -42,7 +43,7 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
         expect(metadata[:collection]).to be_truthy
         expect(metadata[:path]).to eq("/td-test-001/collection-96-58278")
         expect(metadata[:type]).to eq("application/arc-asset-collection")
-        expect(metadata[:size]).to eq("")
+        expect(metadata[:size]).to eq("6 KB")
         expect(WebMock).to have_requested(:post, mediflux_url)
       end
     end

--- a/spec/models/mediaflux/http/get_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/get_metadata_request_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
       expect(metadata[:collection]).to be_falsey
       expect(metadata[:path]).to eq("/td-test-001/collection-96-55948/file-96-57045")
       expect(metadata[:type]).to eq("content/unknown")
-      expect(metadata[:size]).to eq("")
-      expect(metadata[:size_human]).to eq("")
       expect(WebMock).to have_requested(:post, mediflux_url)
     end
 
@@ -44,8 +42,6 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
         expect(metadata[:collection]).to be_truthy
         expect(metadata[:path]).to eq("/td-test-001/collection-96-58278")
         expect(metadata[:type]).to eq("application/arc-asset-collection")
-        expect(metadata[:size]).to eq("")
-        expect(metadata[:size_human]).to eq("")
         expect(WebMock).to have_requested(:post, mediflux_url)
       end
     end

--- a/spec/models/mediaflux/http/get_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/get_metadata_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Mediaflux::Http::GetMetadataRequest, type: :model do
         expect(metadata[:collection]).to be_truthy
         expect(metadata[:path]).to eq("/td-test-001/collection-96-58278")
         expect(metadata[:type]).to eq("application/arc-asset-collection")
+        expect(metadata[:size]).to eq("")
         expect(WebMock).to have_requested(:post, mediflux_url)
       end
     end

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -608,7 +608,6 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
 
         it "renders the storage capacity in the show view" do
           visit project_contents_path(project_in_mediaflux)
-
           expect(page).to have_content "0 KB / 100 TB"
           expect(page).to be_axe_clean
             .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)


### PR DESCRIPTION
Setting the metadata value for the size accumulator when querying a collection in mediaflux

Fixes #581