### PR TITLE
Speed up CI by not re-installing firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   build: # name of your job
     working_directory: ~/tiger_data
     machine: # executor type
-      image: ubuntu-2004:2023.10.1
+      image: default
       docker_layer_caching: true
     environment:
         POSTGRES_USER: tiger_data_user
@@ -52,10 +52,11 @@ jobs:
       - install_dependencies
       - persist_to_workspace:
           root: &root '~/tiger_data'
-          paths: ['*']
+          paths: '*'
       - run:
           name: Run rubocop
           command: bundle exec rubocop
+          paths: '*'
       - run:
           name: Run eslint
           command: yarn run eslint 'app/javascript/**'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   build: # name of your job
     working_directory: ~/tiger_data
     machine: # executor type
-      image: default
+      image: ubuntu-2004:2023.10.1
       docker_layer_caching: true
     environment:
         POSTGRES_USER: tiger_data_user
@@ -52,18 +52,16 @@ jobs:
       - install_dependencies
       - persist_to_workspace:
           root: &root '~/tiger_data'
-          paths: '*'
+          paths: ['*']
       - run:
           name: Run rubocop
           command: bundle exec rubocop
-          paths: '*'
       - run:
           name: Run eslint
           command: yarn run eslint 'app/javascript/**'
       - run:
           name: Run vitest
           command: yarn run vitest run --coverage
-      - browser-tools/install-firefox
       - run_mediaflux
       - run_postgres
       # wait for postgres and mediaflux


### PR DESCRIPTION
I don't believe we have a requirement for a specific version of firefox, so if we use the one that's already installed on the base machine image instead of installing the latest version, it'll save us about a minute on each CI run.

<img width="1020" alt="Screenshot 2024-03-22 at 1 20 11 PM" src="https://github.com/pulibrary/tiger-data-app/assets/65608/2c25a1b3-c05f-4032-8ce3-6399d2fb4263">
