### PR TITLE
memoizing mediaflux metadata request

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
 
   describe "#mediaflux_metadata" do
     let(:project) { FactoryBot.create(:project) }
-    it "calls out to mediaflux once" do 
-      metadata_request = instance_double Mediaflux::Http::GetMetadataRequest, metadata:{}
+    it "calls out to mediaflux once" do
+      metadata_request = instance_double Mediaflux::Http::GetMetadataRequest, metadata: {}
       allow(Mediaflux::Http::GetMetadataRequest).to receive(:new).and_return(metadata_request)
-      project.mediaflux_metadata(session_id: '')
-      project.mediaflux_metadata(session_id: '') #intentionally calling twice, to see if mediaflux is only called once.
+      project.mediaflux_metadata(session_id: "")
+      project.mediaflux_metadata(session_id: "") # intentionally calling twice, to see if mediaflux is only called once.
       expect(Mediaflux::Http::GetMetadataRequest).to have_received(:new).once
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -156,4 +156,15 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
       expect(file_list[:files][0].last_modified).to eq "2024-02-12T11:43:25-05:00"
     end
   end
+
+  describe "#mediaflux_metadata" do
+    let(:project) { FactoryBot.create(:project) }
+    it "calls out to mediaflux once" do 
+      metadata_request = instance_double Mediaflux::Http::GetMetadataRequest, metadata:{}
+      allow(Mediaflux::Http::GetMetadataRequest).to receive(:new).and_return(metadata_request)
+      project.mediaflux_metadata(session_id: '')
+      project.mediaflux_metadata(session_id: '') #intentionally calling twice, to see if mediaflux is only called once.
+      expect(Mediaflux::Http::GetMetadataRequest).to have_received(:new).once
+    end
+  end
 end


### PR DESCRIPTION
memoizing the mediaflux metadata method to reduce the number of calls to mediaflux                                                                                                                                                           fixing tiny bug with storage capacity

closes #604 