### PR TITLE
adding a confirmation page for sysadmins who approve projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -122,7 +122,6 @@ class ProjectsController < ApplicationController
     if params.key?("mediaflux_id")
       project.mediaflux_id = params["mediaflux_id"]
       project.metadata_json["status"] = Project::APPROVE_STATUS
-      params.delete("mediaflux_id")
     end
 
     #Edit action
@@ -136,7 +135,9 @@ class ProjectsController < ApplicationController
     end
 
     # @todo ProjectMetadata should be refactored to implement ProjectMetadata.valid?(updated_metadata)
-    if project.save
+    if project.save and params.key?("mediaflux_id")
+      redirect_to project_approval_received_path(@project)
+    elsif project.save and params.key?("title")
       redirect_to project_revision_confirmation_path(@project)
     else
       render :edit

--- a/app/views/projects/approval_received.html.erb
+++ b/app/views/projects/approval_received.html.erb
@@ -1,0 +1,12 @@
+  <div class="pending-project">
+  <h2> Project Approval Received </h2>
+
+    <p>Thank you for your approval.</p>
+
+    <p>The Data Sponsor and Data Manager will be notified shortly.</p>
+
+    <p>If there are any issues in confirming the Active status of the project, you will receive a message at td-support@princeton.edu</p>
+
+  <%= button_to "Return to Dashboard", root_path, class: "btn btn-primary btn-sm", method: :get %>
+
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get "projects/:id/list-contents", to: "projects#list_contents", as: :project_list_contents
   get "projects/:id/revision_confirmation", to: "projects#revision_confirmation", as: :project_revision_confirmation
   get "projects/file_list_download/:job_id", to: "projects#file_list_download", as: :project_file_list_download
+  get "projects/:id/approval_received", to: "projects#approval_received", as: :project_approval_received
 
   namespace :api do
     namespace :v0 do

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -452,6 +452,28 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
 
       # redirects the user to the project show page
     end
+
+    it "redirects the user to the revision request confirmation page upon submission" do
+      sign_in sysadmin_user
+      expect(project.mediaflux_id).to be nil
+      expect(project.metadata_json["status"]).to eq Project::PENDING_STATUS
+
+      visit project_approve_path(project)
+      expect(page).to have_content("Project Approval: #{project.metadata_json['title']}")
+
+      fill_in "mediaflux_id", with: mediaflux_id
+      click_on "Approve"
+
+      # This is the confirmation page. It needs a button to return to the dashboard
+      # and it needs to be_axe_clean.
+      expect(page).to have_content "Project Approval Received"
+      expect(page).to have_button "Return to Dashboard"
+      expect(page).to be_axe_clean
+        .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)
+        .skipping(:'color-contrast')
+      click_on "Return to Dashboard"
+      expect(page).to have_content "Approved Projects"
+    end
   end
 
   context "GET /projects/:id/content" do


### PR DESCRIPTION
- closes #575 
- adds route for project approval received
- redirects the approve button to the approval received
- writing tests