### PR TITLE
Linking pending projects to the Details page

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -70,7 +70,7 @@
             <ul class="project-list">
               <% @pending_projects.each do |project| %>
                 <li>
-                  <%= link_to(project.title, project_approve_path(project)) %>
+                  <%= link_to(project.title, project) %>
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
making projects listed under pending projects route the user to the details page instead of the approve page

- closes #572 