### PR TITLE
WIP: setting up activate method project in project metadata

### DIFF
--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -15,14 +15,14 @@ class ProjectMetadata
   end
 
   def activate_project(collection_id:)
-    response = MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)
+    response = Mediaflux::Http::GetMetadataRequest.new(session_token: current_user.mediaflux_session, id: collection_id)
     metadata = response.metadata
     return unless metadata[:collection] == true # If the collection id exists
     
      # check if the project doi in rails matches the project doi in mediaflux
     xml = response.response_xml
     asset = xml.xpath("/response/reply/result/asset")
-    doi = asset.xpath("./meta/tigerdata:project/ProjectID")
+    doi = asset.xpath("//tigerdata:project/ProjectID", "tigerdata" => "tigerdata").text
     return unless doi == project.metadata_json["project_id"]
     
     #activate a project by setting the status to 'active' 
@@ -30,8 +30,7 @@ class ProjectMetadata
     project.save!
     
     #create two provenance events, one for approving the project and another for changing the status of the project
-    #TODO: FILL THE APPROPRIATE EVENT DETAILS
-    project.provenance_events.create(event_type: ProvenanceEvent::ACTIVE_EVENT_TYPE, event_person: current_user.uid, event_details: "Approved by #{current_user.display_name_safe}")
+    project.provenance_events.create(event_type: ProvenanceEvent::ACTIVE_EVENT_TYPE, event_person: current_user.uid, event_details: "Activated by Tigerdata Staff")
     project.provenance_events.create(event_type: ProvenanceEvent::STATUS_UPDATE_EVENT_TYPE, event_person: current_user.uid, event_details: "The Status of this project has been set to active")
   end
 

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -14,6 +14,23 @@ class ProjectMetadata
     form_metadata
   end
 
+  def activate_project(collection_id:)
+    #TODO: FIGURE OUT THE VALID BOOLEAN RESPONSE FOR A MEDIAFLUX QUERY
+    return unless (MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)) # If the collection id exists
+    
+    byebug # check if the project doi in rails matches the project doi in mediaflux
+    
+
+    #activate a project by setting the status to 'active' 
+    project.metadata_json["status"] = Project::ACTIVE_STATUS
+    project.save!
+    
+    #create two provenance events, one for approving the project and another for changing the status of the project
+    #TODO: FILL THE APPROPRIATE EVENT DETAILS
+    project.provenance_events.create(event_type: ProvenanceEvent::ACTIVE_EVENT_TYPE, event_person: current_user.uid, event_details: "Approved by #{current_user.display_name_safe}")
+    project.provenance_events.create(event_type: ProvenanceEvent::STATUS_UPDATE_EVENT_TYPE, event_person: current_user.uid, event_details: "The Status of this project has been set to active")
+  end
+
   def approve_project(params:)
     #approve a project by recording the mediaflux id & setting the status to 'approved' 
     project.mediaflux_id = params[:mediaflux_id]

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -16,7 +16,8 @@ class ProjectMetadata
 
   def activate_project(collection_id:)
     #TODO: FIGURE OUT THE VALID BOOLEAN RESPONSE FOR A MEDIAFLUX QUERY
-    return unless (MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)) # If the collection id exists
+    metadata = MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)
+    return unless metadata[:collection] == true # If the collection id exists
     
     byebug # check if the project doi in rails matches the project doi in mediaflux
     

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -15,13 +15,15 @@ class ProjectMetadata
   end
 
   def activate_project(collection_id:)
-    #TODO: FIGURE OUT THE VALID BOOLEAN RESPONSE FOR A MEDIAFLUX QUERY
-    metadata = MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)
+    response = MEDIAFLUX::HTTP::GetMetadataRequest(session_token: current_user.mediaflux_session, id: collection_id)
+    metadata = response.metadata
     return unless metadata[:collection] == true # If the collection id exists
     
-    byebug # check if the project doi in rails matches the project doi in mediaflux
-    
-
+     # check if the project doi in rails matches the project doi in mediaflux
+    xml = response.response_xml
+    asset = xml.xpath("/response/reply/result/asset")
+    doi = asset.xpath("./meta/tigerdata:project/ProjectID")
+    return unless doi == project.metadata_json["project_id"]
     #activate a project by setting the status to 'active' 
     project.metadata_json["status"] = Project::ACTIVE_STATUS
     project.save!

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -24,6 +24,7 @@ class ProjectMetadata
     asset = xml.xpath("/response/reply/result/asset")
     doi = asset.xpath("./meta/tigerdata:project/ProjectID")
     return unless doi == project.metadata_json["project_id"]
+    
     #activate a project by setting the status to 'active' 
     project.metadata_json["status"] = Project::ACTIVE_STATUS
     project.save!

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       title { FFaker::Movie.title }
       created_on { Time.current.in_time_zone("America/New_York").iso8601 }
       updated_on { Time.current.in_time_zone("America/New_York").iso8601 }
-      project_id { "10.34770/tbd" }
+      project_id { nil }
       status { "pending" }
       storage_capacity { "500 GB" }
       storage_performance { "standard" }

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       title { FFaker::Movie.title }
       created_on { Time.current.in_time_zone("America/New_York").iso8601 }
       updated_on { Time.current.in_time_zone("America/New_York").iso8601 }
-      project_id { nil }
+      project_id { "10.34770/tbd" }
       status { "pending" }
       storage_capacity { "500 GB" }
       storage_performance { "standard" }

--- a/spec/models/project_metadata_spec.rb
+++ b/spec/models/project_metadata_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe ProjectMetadata, type: :model do
         expect(status_update_event.event_details).to eq "The Status of this project has been set to pending"
       end
 
-
       it "does not call out to draft a doi if one isalready set" do
         project.metadata_json["project_id"] = "aaabbb123"
         project_metadata = described_class.new(current_user: current_user, project:)
@@ -145,27 +144,27 @@ RSpec.describe ProjectMetadata, type: :model do
     end
 
     describe "#approve_project" do
-    it "Records the mediaflux id and sets the status to approved" do 
-      project_metadata = described_class.new(current_user: current_user, project:)
-      params = {mediaflux_id: 001 }
-      project_metadata.approve_project(params:)
-      
-      project.reload
+      it "Records the mediaflux id and sets the status to approved" do 
+        project_metadata = described_class.new(current_user: current_user, project:)
+        params = {mediaflux_id: 001 }
+        project_metadata.approve_project(params:)
+        
+        project.reload
 
-      expect(project.mediaflux_id).not_to be_nil
-      expect(project.metadata_json["status"]).to eq Project::APPROVED_STATUS
-    end
-    it "Creates a Provenance Event: Approval" do
-      project_metadata = described_class.new(current_user: current_user, project:)
-      params = {data_sponsor: "abc", data_manager: "def", departments: "dep", directory: "dir", title: "title abc", description: "description 123" }
-      project_metadata.approve_project(params: {}) # doesn't call the doi service twice
-      
-      project.reload
-      expect(project.provenance_events.count).to eq 2
-      approval_event = project.provenance_events.first #testing the approval Event
-      expect(approval_event.event_type).to eq ProvenanceEvent::APPROVAL_EVENT_TYPE
-      expect(approval_event.event_person).to eq current_user.uid
-      expect(approval_event.event_details).to eq "Approved by #{current_user.display_name_safe}"
+        expect(project.mediaflux_id).not_to be_nil
+        expect(project.metadata_json["status"]).to eq Project::APPROVED_STATUS
+      end
+      it "Creates a Provenance Event: Approval" do
+        project_metadata = described_class.new(current_user: current_user, project:)
+        params = {data_sponsor: "abc", data_manager: "def", departments: "dep", directory: "dir", title: "title abc", description: "description 123" }
+        project_metadata.approve_project(params: {}) # doesn't call the doi service twice
+        
+        project.reload
+        expect(project.provenance_events.count).to eq 2
+        approval_event = project.provenance_events.first #testing the approval Event
+        expect(approval_event.event_type).to eq ProvenanceEvent::APPROVAL_EVENT_TYPE
+        expect(approval_event.event_person).to eq current_user.uid
+        expect(approval_event.event_details).to eq "Approved by #{current_user.display_name_safe}"
       end
     end
 
@@ -177,7 +176,7 @@ RSpec.describe ProjectMetadata, type: :model do
       after do
         Rails.configuration.mediaflux["api_host"] = @original_api_host
       end
-      let(:valid_project) { FactoryBot.create(:project, directory: "something-else")}
+      let(:valid_project) { FactoryBot.create(:project, directory: "something-else", project_id: "10.34770/tbd")}
       let(:project_metadata) {described_class.new(current_user:, project: valid_project)}
       it "validates the doi for a project" do
         params = {mediaflux_id: 001 }

--- a/spec/models/project_metadata_spec.rb
+++ b/spec/models/project_metadata_spec.rb
@@ -197,22 +197,19 @@ RSpec.describe ProjectMetadata, type: :model do
         xml = response.response_xml
         asset = xml.xpath("/response/reply/result/asset")
         doi = asset.xpath("//tigerdata:project/ProjectID", "tigerdata" => "tigerdata").text
-        expect(doi).to eq project.metadata_json["project_id"]
+        expect(doi).to eq valid_project.metadata_json["project_id"]
 
         #change the status of the project to active
-        project.metadata_json["status"] = Project::ACTIVE_STATUS
-        project.save!
-        expect(project.metadata_json["status"]).to eq Project::ACTIVE_STATUS
+        valid_project.metadata_json["status"] = Project::ACTIVE_STATUS
+        valid_project.save!
+        expect(valid_project.metadata_json["status"]).to eq Project::ACTIVE_STATUS
 
         #activate the project by setting the status to active and creating the necessary provenance events
-        project.provenance_events.create(event_type: ProvenanceEvent::ACTIVE_EVENT_TYPE, event_person: current_user.uid, event_details: "Activated by Tigerdata Staff")
-        project.provenance_events.create(event_type: ProvenanceEvent::STATUS_UPDATE_EVENT_TYPE, event_person: current_user.uid, event_details: "The Status of this project has been set to active")
-        expect(project.provenance_events.count).to eq 2
-        activate_event = project.provenance_events.first #testing the approval Event
+        expect(valid_project.provenance_events.count).to eq 4
+        activate_event = valid_project.provenance_events.third #testing the approval Event
         expect(activate_event.event_type).to eq ProvenanceEvent::ACTIVE_EVENT_TYPE
         expect(activate_event.event_person).to eq current_user.uid
         expect(activate_event.event_details).to eq "Activated by Tigerdata Staff"
-        byebug
       end
     end
   end


### PR DESCRIPTION
1) Query mediaflux with an approved projects collection id
2) Validate that the project in rails and mediaflux have matching DOIs
3) Set the status of the active project to `ACTIVE_STATUS`
4) Create `ACTIVE_EVENT_TYPE` and `STATUS_UPDATE_EVENT_TYPE` Provenance Events

Closes #640 