### PR TITLE
Ensure unique namespace values in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ aterm.jar
 
 public 
 doc
+
+# Ignore test created to not get accidentally added to commit
+project_create_8.txt

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -39,5 +39,12 @@ FactoryBot.define do
         project_purpose: project_purpose
       }
     end
+    factory :project_with_dynamic_directory, class: "Project" do
+      transient do
+        sequence :directory do |n|
+          "#{FFaker::Food.fruit}#{n}"
+        end
+      end
+    end
   end
 end

--- a/spec/models/project_metadata_spec.rb
+++ b/spec/models/project_metadata_spec.rb
@@ -169,8 +169,11 @@ RSpec.describe ProjectMetadata, type: :model do
     end
 
     describe "#activate_project", connect_to_mediaflux: true do 
-      let(:valid_project) { FactoryBot.create(:project, directory: "something-else", project_id: "10.34770/tbd")}
+      let(:valid_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
       let(:project_metadata) {described_class.new(current_user:, project: valid_project)}
+      after do 
+        Mediaflux::Http::DestroyAssetRequest.new(session_token: current_user.mediaflux_session, collection: valid_project.mediaflux_id, members: true).resolve
+      end
       it "validates the doi for a project" do
         params = {mediaflux_id: 001 }
         project_metadata.approve_project(params:)


### PR DESCRIPTION
Ref #615 

Mediaflux will raise an error on namespace collision.

Ensure that tests which are creating namespaces in Mediaflux have a good chance of not colliding.