### PR TITLE
Mediaflux silently fails to create a project with missing metadata

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,7 +16,7 @@ class Project < ApplicationRecord
   end
 
   def metadata_model
-    ProjectMetadata.new(project: self)
+    @metadata_model ||= ProjectMetadata.new(project: self)
   end
 
   def metadata=(metadata)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,10 @@ class Project < ApplicationRecord
     (metadata_json || {}).with_indifferent_access
   end
 
+  def metadata_model
+    ProjectMetadata.new(project: self)
+  end
+
   def metadata=(metadata)
     self.metadata_json = metadata
   end

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -31,8 +31,10 @@ class ProjectMediaflux
       when "failed: The namespace #{project_namespace} already contains an asset named '#{project_name}'"
         raise "Project name already taken"
       when /'asset.create' failed/
-        project.metadata_model.valid?
-        raise TigerData::MissingMetadata.missing_metadata(schema_version:"0.6",fields: project.metadata_model.errors)
+
+        # Ensure that the metadata validations are run
+        project.metadata_model.validate
+        raise TigerData::MissingMetadata.missing_metadata(schema_version:"0.6", errors: project.metadata_model.errors)
       else
         raise(StandardError,"An error has occured during project creation, not related to namespace creation or collection creation")
       end

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -20,6 +20,9 @@ class ProjectMediaflux
     prepare_parent_collection(project_parent:, session_id:)
     create_request = Mediaflux::Http::CreateAssetRequest.new(session_token: session_id, namespace: project_namespace, name: project_name, tigerdata_values: tigerdata_values,
                                                              xml_namespace: xml_namespace, pid: project_parent)
+
+          #TODO: custom exception class raised for metadata issues. This would allow us to see them in Honeybadger and know how often they're happening. 
+          #All exceptions that are raised should include the current expected metadata schema version number, as well as what metadata is missing.
     id = create_request.id
     if id.blank? && create_request.response_xml.text.include?("failed: The namespace #{project_namespace} already contains an asset named '#{project_name}'")
       raise "Project name already taken"

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -24,9 +24,9 @@ class ProjectMediaflux
           #TODO: custom exception class raised for metadata issues. This would allow us to see them in Honeybadger and know how often they're happening. 
           #All exceptions that are raised should include the current expected metadata schema version number, as well as what metadata is missing.
     id = create_request.id
-    response_xml = create_request.response_xml
-    response_text = response_xml.text
     if id.blank?
+      response_xml = create_request.response_xml
+      response_text = response_xml.text
       case response_text
       when "failed: The namespace #{project_namespace} already contains an asset named '#{project_name}'"
         raise "Project name already taken"

--- a/app/models/tigerdata_schema.rb
+++ b/app/models/tigerdata_schema.rb
@@ -62,7 +62,7 @@ class TigerdataSchema
   end
 
   # rubocop:disable Metrics/MethodLength
-  def project_schema_fields
+  def self.project_schema_fields
     # WARNING: Do not use `id` as field name, MediaFlux uses specific rules for an `id` field.
     code = { name: "Code", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "Code", description: "The unique identifier for the project" }
     title = { name: "Title", type: "string", index: false, "min-occurs" => 1, "max-occurs" => 1, label: "Title", 
@@ -125,6 +125,13 @@ class TigerdataSchema
      storage_performance, project_purpose]
   end
   # rubocop:enable Metrics/MethodLength
+  def project_schema_fields
+    self.class.project_schema_fields
+  end
+
+  def self.required_project_schema_fields
+    project_schema_fields.select { |field| field["min-occurs"] > 0 }
+  end
 
   private
 

--- a/lib/tiger_data/metadata_error.rb
+++ b/lib/tiger_data/metadata_error.rb
@@ -3,12 +3,11 @@ module TigerData
   class MetadataError < StandardError
   end
 
-  class MissingMetadata 
-        def self.missing_metadata(schema_version:, fields:)
-            # include current expected metadata schema version number, as well as what metadata is missing
-            @fields = fields
-            byebug
-            raise TigerData::MetadataError, "My error msg" if true
-        end
+  class MissingMetadata
+    def self.missing_metadata(schema_version:, errors:)
+      error_messages = errors.full_messages.join
+      # include current expected metadata schema version number, as well as what metadata is missing
+      raise TigerData::MetadataError, "Project failed to create with metadata schema version #{schema_version} with the missing fields: #{error_messages}"
     end
+  end
 end

--- a/lib/tiger_data/metadata_error.rb
+++ b/lib/tiger_data/metadata_error.rb
@@ -3,8 +3,12 @@ module TigerData
   class MetadataError < StandardError
   end
 
-  def missing_metadata(schema_version:, metadata:)
-    # include current expected metadata schema version number, as well as what metadata is missing
-    raise TigerData::MetadataError, "My error msg" unless true
-  end
+  class MissingMetadata 
+        def self.missing_metadata(schema_version:, fields:)
+            # include current expected metadata schema version number, as well as what metadata is missing
+            @fields = fields
+            byebug
+            raise TigerData::MetadataError, "My error msg" if true
+        end
+    end
 end

--- a/lib/tiger_data/metadata_error.rb
+++ b/lib/tiger_data/metadata_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module TigerData
+  class MetadataError < StandardError
+  end
+
+  def missing_metadata(schema_version:, metadata:)
+    # include current expected metadata schema version number, as well as what metadata is missing
+    raise TigerData::MetadataError, "My error msg" unless true
+  end
+end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
         it "raises an error" do
           expect do
             described_class.create!(project: project, session_id: "test-session-token")
-          end.to raise_error(RuntimeError)
+          end.to raise_error(StandardError) #Raises standard error when a duplicate project already exists
         end
       end
 

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -89,14 +89,20 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
       after do
         Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
       end
-      it "fails to create a project" do
+      it "should raise a MetadataError if any required is missing" do
         params = {mediaflux_id: 001 }
         project_metadata.approve_project(params:)
 
         #create a project in mediaflux
         session_token = current_user.mediaflux_session
         collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
-        expect(collection_id).to eq ""
+        expect(collection_id).to be_blank
+
+        #raise a metadata error & log what specific required fields are missing
+        error = assert_raises(Tigerdata::MetadataError) {
+          Tigerdata.new.missing_metadata
+        }
+        assert error.message = "My error msg"
       end
     end
   end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -13,90 +13,92 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
   let(:create_asset_request) { instance_double(Mediaflux::Http::GetMetadataRequest) }
 
   describe "#create!" do
-    before do
-      allow(Mediaflux::Http::NamespaceCreateRequest).to receive(:new).with(session_token: "test-session-token",
-                                                                           namespace: "/td-test-001/tigerdataNS/big-dataNS",
-                                                                           description: "Namespace for project #{project.title}",
-                                                                           store: "db").and_return(namespace_request)
-      allow(Mediaflux::Http::CreateAssetRequest).to receive(:new).with(hash_including(session_token: "test-session-token", name: "big-data",
-                                                                                      namespace: "/td-test-001/tigerdataNS/big-dataNS",
-                                                                                      pid: "path=/td-test-001/tigerdata")).and_return(create_asset_request)
-      allow(Mediaflux::Http::GetMetadataRequest).to receive(:new).with(hash_including(session_token: "test-session-token",
-                                                                                      id: "path=/td-test-001/tigerdata")).and_return(parent_metadata_request)
-      allow(create_asset_request).to receive(:resolve).and_return("<xml>...")
-      allow(create_asset_request).to receive(:id).and_return("123")
-    end
-
-    context "it formats dates correctly for MediaFlux" do
-      let(:project) { FactoryBot.build(:project, created_on: "2024-02-22T13:57:19-05:00", updated_on: "2024-02-26T13:57:19-05:00") }
-      it "formats created_on as expected" do
-        project_values = ProjectMediaflux.project_values(project: project)
-        expect(project_values[:created_on]).to eq "22-FEB-2024 13:57:19"
-      end
-      it "formats updated_on as expected" do
-        project_values = ProjectMediaflux.project_values(project: project)
-        expect(project_values[:updated_on]).to eq "26-FEB-2024 13:57:19"
-      end
-    end
-
-    it "creates a project namespace and collection and returns the mediaflux id" do
-      mediaflux_id = described_class.create!(project: project, session_id: "test-session-token")
-      expect(namespace_request).to have_received("error?")
-      expect(parent_metadata_request).to have_received("error?")
-      expect(create_asset_request).to have_received("id")
-      expect(mediaflux_id).to be "123"
-    end
-
-    context "when the name is already taken" do
-      let(:mediaflux_create_fixture_path) { Rails.root.join("spec", "fixtures", "files", "asset_create_error_response.xml") }
-      let(:mediaflux_create_body) { Nokogiri::XML.parse(File.read(mediaflux_create_fixture_path)) }
-
+    context "Using test data" do
       before do
-        allow(create_asset_request).to receive(:id).and_return(nil)
-        allow(create_asset_request).to receive(:response_xml).and_return(mediaflux_create_body)
+        allow(Mediaflux::Http::NamespaceCreateRequest).to receive(:new).with(session_token: "test-session-token",
+                                                                            namespace: "/td-test-001/tigerdataNS/big-dataNS",
+                                                                            description: "Namespace for project #{project.title}",
+                                                                            store: "db").and_return(namespace_request)
+        allow(Mediaflux::Http::CreateAssetRequest).to receive(:new).with(hash_including(session_token: "test-session-token", name: "big-data",
+                                                                                        namespace: "/td-test-001/tigerdataNS/big-dataNS",
+                                                                                        pid: "path=/td-test-001/tigerdata")).and_return(create_asset_request)
+        allow(Mediaflux::Http::GetMetadataRequest).to receive(:new).with(hash_including(session_token: "test-session-token",
+                                                                                        id: "path=/td-test-001/tigerdata")).and_return(parent_metadata_request)
+        allow(create_asset_request).to receive(:resolve).and_return("<xml>...")
+        allow(create_asset_request).to receive(:id).and_return("123")
       end
 
-      it "raises an error" do
-        expect do
-          described_class.create!(project: project, session_id: "test-session-token")
-        end.to raise_error(RuntimeError)
-      end
-    end
-
-    context "when the parent colllection does not exist" do
-      let(:parent_metadata_request) { instance_double(Mediaflux::Http::GetMetadataRequest, metadata: {}, "error?": true) }
-      let(:parent_collection_request) { instance_double(Mediaflux::Http::CreateAssetRequest, id: 567, "error?": false) }
-
-      before do
-        allow(Mediaflux::Http::CreateAssetRequest).to receive(:new).with(hash_including(session_token: "test-session-token", name: "tigerdata",
-                                                                                        namespace: "/td-test-001")).and_return(parent_collection_request)
+      context "it formats dates correctly for MediaFlux" do
+        let(:project) { FactoryBot.build(:project, created_on: "2024-02-22T13:57:19-05:00", updated_on: "2024-02-26T13:57:19-05:00") }
+        it "formats created_on as expected" do
+          project_values = ProjectMediaflux.project_values(project: project)
+          expect(project_values[:created_on]).to eq "22-FEB-2024 13:57:19"
+        end
+        it "formats updated_on as expected" do
+          project_values = ProjectMediaflux.project_values(project: project)
+          expect(project_values[:updated_on]).to eq "26-FEB-2024 13:57:19"
+        end
       end
 
-      it "creates a project namespace and collection and parent collection and returns the mediaflux id" do
+      it "creates a project namespace and collection and returns the mediaflux id" do
         mediaflux_id = described_class.create!(project: project, session_id: "test-session-token")
         expect(namespace_request).to have_received("error?")
-        expect(parent_collection_request).to have_received("error?")
+        expect(parent_metadata_request).to have_received("error?")
         expect(create_asset_request).to have_received("id")
         expect(mediaflux_id).to be "123"
       end
+
+      context "when the name is already taken" do
+        let(:mediaflux_create_fixture_path) { Rails.root.join("spec", "fixtures", "files", "asset_create_error_response.xml") }
+        let(:mediaflux_create_body) { Nokogiri::XML.parse(File.read(mediaflux_create_fixture_path)) }
+
+        before do
+          allow(create_asset_request).to receive(:id).and_return(nil)
+          allow(create_asset_request).to receive(:response_xml).and_return(mediaflux_create_body)
+        end
+
+        it "raises an error" do
+          expect do
+            described_class.create!(project: project, session_id: "test-session-token")
+          end.to raise_error(RuntimeError)
+        end
+      end
+
+      context "when the parent colllection does not exist" do
+        let(:parent_metadata_request) { instance_double(Mediaflux::Http::GetMetadataRequest, metadata: {}, "error?": true) }
+        let(:parent_collection_request) { instance_double(Mediaflux::Http::CreateAssetRequest, id: 567, "error?": false) }
+
+        before do
+          allow(Mediaflux::Http::CreateAssetRequest).to receive(:new).with(hash_including(session_token: "test-session-token", name: "tigerdata",
+                                                                                          namespace: "/td-test-001")).and_return(parent_collection_request)
+        end
+
+        it "creates a project namespace and collection and parent collection and returns the mediaflux id" do
+          mediaflux_id = described_class.create!(project: project, session_id: "test-session-token")
+          expect(namespace_request).to have_received("error?")
+          expect(parent_collection_request).to have_received("error?")
+          expect(create_asset_request).to have_received("id")
+          expect(mediaflux_id).to be "123"
+        end
+      end
     end
+    context "when the metadata of a project is incomplete", connect_to_mediaflux: true do
+      let(:incomplete_project) { FactoryBot.create(:project_with_dynamic_directory)}
+      let(:project_metadata) {ProjectMetadata.new(current_user:, project: incomplete_project)}
+      let(:namespace_request) {Mediaflux::Http::NamespaceCreateRequest}
+      after do
+        Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
+      end
+      it "fails to create a project" do
+        params = {mediaflux_id: 001 }
+        project_metadata.approve_project(params:)
 
-    # context "when the metadata of a project is incomplete", connect_to_mediaflux: true do
-    #   let(:incomplete_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
-    #   let(:project_metadata) {ProjectMetadata.new(current_user:, project: incomplete_project)}
-    #   let(:namespace_request) {Mediaflux::Http::NamespaceCreateRequest}
-    #   after do
-    #     Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
-    #   end
-    #   it "fails to create a project" do
-    #     params = {mediaflux_id: 001 }
-    #     project_metadata.approve_project(params:)
-
-    #     #create a project in mediaflux
-    #     session_token = current_user.mediaflux_session
-    #     collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
-    #   end
-    # end
+        #create a project in mediaflux
+        session_token = current_user.mediaflux_session
+        collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
+        expect(collection_id).to eq ""
+      end
+    end
   end
 
   describe "#safe_name" do

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
     #   let(:incomplete_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
     #   let(:project_metadata) {ProjectMetadata.new(current_user:, project: incomplete_project)}
     #   let(:namespace_request) {Mediaflux::Http::NamespaceCreateRequest}
-    #   after do 
+    #   after do
     #     Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
     #   end
     #   it "fails to create a project" do
     #     params = {mediaflux_id: 001 }
     #     project_metadata.approve_project(params:)
-        
+
     #     #create a project in mediaflux
     #     session_token = current_user.mediaflux_session
     #     collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
   let(:parent_metadata_request) { instance_double(Mediaflux::Http::GetMetadataRequest, "error?": false) }
   let(:collection_metadata) { { id: "abc", name: "test", path: "td-demo-001/rc/test-ns/test", description: "description", namespace: "td-demo-001/rc/test-ns" } }
   let(:project) { FactoryBot.build :project }
+  let(:current_user) { FactoryBot.create(:user, uid: "jh1234") }
 
   let(:create_asset_request) { instance_double(Mediaflux::Http::GetMetadataRequest) }
 
@@ -79,6 +80,23 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
         expect(mediaflux_id).to be "123"
       end
     end
+
+    # context "when the metadata of a project is incomplete", connect_to_mediaflux: true do
+    #   let(:incomplete_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
+    #   let(:project_metadata) {ProjectMetadata.new(current_user:, project: incomplete_project)}
+    #   let(:namespace_request) {Mediaflux::Http::NamespaceCreateRequest}
+    #   after do 
+    #     Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
+    #   end
+    #   it "fails to create a project" do
+    #     params = {mediaflux_id: 001 }
+    #     project_metadata.approve_project(params:)
+        
+    #     #create a project in mediaflux
+    #     session_token = current_user.mediaflux_session
+    #     collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
+    #   end
+    # end
   end
 
   describe "#safe_name" do

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -94,9 +94,12 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
         session_token = current_user.mediaflux_session
         
         #raise a metadata error & log what specific required fields are missing when writing a project to mediaflux
-        expect{
+        expect {
           collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
-      }.to raise_error(TigerData::MetadataError,"My error msg")
+        }.to raise_error do |error|
+          expect(error).to be_a(TigerData::MetadataError)
+          expect(error.message).to include("Project failed to create with metadata schema version 0.6 with the missing fields:")
+        end
       end
     end
   end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
   let(:collection_metadata) { { id: "abc", name: "test", path: "td-demo-001/rc/test-ns/test", description: "description", namespace: "td-demo-001/rc/test-ns" } }
   let(:project) { FactoryBot.build :project }
   let(:current_user) { FactoryBot.create(:user, uid: "jh1234") }
-
   let(:create_asset_request) { instance_double(Mediaflux::Http::GetMetadataRequest) }
 
   describe "#create!" do
@@ -90,19 +89,14 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
         Mediaflux::Http::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: incomplete_project.mediaflux_id, members: true).resolve
       end
       it "should raise a MetadataError if any required is missing" do
-        params = {mediaflux_id: 001 }
+        params = {mediaflux_id: 001}
         project_metadata.approve_project(params:)
-
-        #create a project in mediaflux
         session_token = current_user.mediaflux_session
-        collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
-        expect(collection_id).to be_blank
-
-        #raise a metadata error & log what specific required fields are missing
-        error = assert_raises(Tigerdata::MetadataError) {
-          Tigerdata.new.missing_metadata
-        }
-        assert error.message = "My error msg"
+        
+        #raise a metadata error & log what specific required fields are missing when writing a project to mediaflux
+        expect{
+          collection_id = ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
+      }.to raise_error(TigerData::MetadataError,"My error msg")
       end
     end
   end


### PR DESCRIPTION
testing what error gets returned when we attempt to create a project in mediaflux with missing metadata

closes #650 