### PR TITLE
Save the full path to the database and mediaflux

### DIFF
--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -16,8 +16,8 @@ class ProjectMediaflux
 
     # Create a namespace for the project
     # The namespace is directly under our root namespace'
-    project_name = safe_name(project.project_directory)
-    project_namespace = "#{Rails.configuration.mediaflux['api_root_ns']}/#{project_name}NS"
+    project_name = project.project_directory
+    project_namespace = "#{project_name}NS"
     namespace = Mediaflux::Http::NamespaceCreateRequest.new(namespace: project_namespace, description: "Namespace for project #{project.title}", store: store_name, session_token: session_id)
     if namespace.error?
       raise "Can not create the namespace #{namespace.response_error}"
@@ -26,7 +26,7 @@ class ProjectMediaflux
     tigerdata_values = project_values(project: project)
     project_parent = Rails.configuration.mediaflux["api_root_collection"]
     prepare_parent_collection(project_parent:, session_id:)
-    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: session_id, namespace: project_namespace, name: project_name, tigerdata_values: tigerdata_values,
+    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: session_id, namespace: project_namespace, name: project.project_directory_short, tigerdata_values: tigerdata_values,
                                                              xml_namespace: xml_namespace, pid: project_parent)
 
           #TODO: custom exception class raised for metadata issues. This would allow us to see them in Honeybadger and know how often they're happening. 
@@ -91,12 +91,12 @@ class ProjectMediaflux
   end
 
   def self.xml_payload(project:, xml_namespace: nil)
-    project_name = safe_name(project.project_directory)
-    project_namespace = "#{Rails.configuration.mediaflux['api_root_ns']}/#{project_name}NS"
+    project_name = project.project_directory
+    project_namespace = "#{project_name}NS"
     project_parent = Rails.configuration.mediaflux["api_root_collection"]
 
     tigerdata_values = project_values(project: project)
-    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: nil, namespace: project_namespace, name: project_name, tigerdata_values: tigerdata_values,
+    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: nil, namespace: project_namespace, name: project.project_directory_short, tigerdata_values: tigerdata_values,
                                                              xml_namespace: xml_namespace, pid: project_parent)
     create_request.xml_payload
   end
@@ -104,11 +104,6 @@ class ProjectMediaflux
   def self.document(project:, xml_namespace: nil)
     xml_body = xml_payload(project:, xml_namespace:)
     Nokogiri::XML.parse(xml_body)
-  end
-
-  def self.safe_name(name)
-    # only alphanumeric characters
-    name.strip.gsub(/[^A-Za-z\d]/, "-")
   end
 
   def self.create_root_ns(session_id:)

--- a/app/services/test_asset_generator.rb
+++ b/app/services/test_asset_generator.rb
@@ -7,7 +7,7 @@ class TestAssetGenerator
     @levels = levels
     @directory_per_level = directory_per_level
     @file_count_per_directory = file_count_per_directory
-    @base_name = @project.project_directory
+    @base_name = @project.project_directory_short
     @mediaflux_session = @user.mediaflux_session
   end
 
@@ -29,7 +29,9 @@ class TestAssetGenerator
       return if directory_count == 0
       name_extention = (0...10).map { ("a".."z").to_a[rand(26)] }.join
       dir_collection = Mediaflux::Http::AssetCreateRequest.new(session_token: mediaflux_session, name: "#{base_name}-#{parent_id}-#{name_extention}", pid: parent_id)
-      Mediaflux::Http::TestAssetCreateRequest.new(session_token: mediaflux_session, parent_id: dir_collection.id, count: file_count_per_directory).resolve
+      dir_collection_id = dir_collection.id
+      raise dir_collection.response_error.to_s if dir_collection_id.blank?
+      Mediaflux::Http::TestAssetCreateRequest.new(session_token: mediaflux_session, parent_id: dir_collection_id, count: file_count_per_directory).resolve
       generate_directory(parent_id, directory_count - 1)
     end
 end

--- a/app/views/projects/_approve_form.html.erb
+++ b/app/views/projects/_approve_form.html.erb
@@ -4,8 +4,8 @@
 <div class="container" id="approve">
   <div class="field">
     <label for="project_directory" class="form-label">Confirm Project Directory</label>
-    <input class="form-directory" type="text" name="project_directory-prefix" disabled readonly value= <%= Rails.configuration.mediaflux["api_root_ns"] %>></input> /  
-    <input class="form-directory-confirm" type="text" name="project_directory" required placeholder=<%= "#{@project.metadata[:project_directory]}"%>></input>  
+    <input class="form-directory" type="text" name="project_directory-prefix" disabled readonly value="<%= @project.project_directory_parent_path %>"></input> /  
+    <input class="form-directory-confirm" type="text" name="project_directory" required placeholder=<%= "#{@project.project_directory_short}"%>></input>  
   </div>
   <div class="field">
     <label for="storage_capacity" class="form-label">Confirm Storage Capacity</label>

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -71,12 +71,12 @@
         Make the field readonly so the user cannot change it, but leave it as an HTML INPUT so that it is
         send back to the controller (we don't want to lose this value)
       -->
-      <p>Project Directory: <%= Rails.configuration.mediaflux["api_root_ns"] %>/<input type="text" id="project_directory" name="project_directory" readonly value="<%= @project.metadata[:project_directory] %>" />
+      <p>Project Directory: <%= @project.project_directory_parent_path %>/<input type="text" id="project_directory" name="project_directory" readonly value="<%= @project.project_directory_short %>" />
         (MediaFlux id: <%= @project.mediaflux_id %>)<br/>
         This project has already been saved to Mediaflux and the project_directory cannot be changed</p>
     <% else %>
       <!-- Unicode alphanumeric, minus-dash, and/or underscore characters -->
-      <p>Project Directory: <%= Rails.configuration.mediaflux["api_root_ns"] %>/<input type="text" id="project_directory" name="project_directory" required value="<%= @project.metadata[:project_directory] %>" pattern="[\w\p{L}\-]{1,64}" /></p>
+      <p>Project Directory: <%= @project.project_directory_parent_path %>/<input type="text" id="project_directory" name="project_directory" required value="<%= @project.project_directory_short %>" pattern="[\w\p{L}\-]{1,64}" /></p>
     <% end %>
 
     <p>Title: <input type="text" id="title" name="title" required value="<%= @project.metadata[:title] %>" /></p>

--- a/app/views/projects/approve.html.erb
+++ b/app/views/projects/approve.html.erb
@@ -6,7 +6,7 @@
   <dl>
       <dt>Data Sponsor</dt> <dd><%= @data_sponsor.display_name_safe %></dd>
       <dt>Affiliated Department(s)</dt> <dd><%= @departments %></dd>
-      <dt>Project Directory</dt> <dd><%=  Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:project_directory] %></dd>
+      <dt>Project Directory</dt> <dd><%= @project.project_directory %></dd>
       <dt>Title</dt> <dd><%=@project.metadata[:title] %></dd>
       <dt>Project ID</dt> <dd><%= @project.metadata[:project_id] %></dd>
       <dt>Storage Capacity - Request</dt> <dd><%= "#{@project.metadata[:storage_capacity][:size][:requested]} #{@project.metadata[:storage_capacity][:unit][:requested]}" %></dd>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -57,7 +57,7 @@ Project Details:
       <dd><%= @departments %></dd>
     <% end %>
     <dt>Project Directory</dt>
-    <dd><%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:project_directory] %></dd>
+    <dd><%= @project.project_directory %></dd>
     <dt>Title</dt>
     <dd><%= @project.metadata[:title] %></dd>
     <dt>Description:<dt/> <dd><%= @project.metadata[:description] %></dd>

--- a/app/views/tigerdata_mailer/project_creation.html.erb
+++ b/app/views/tigerdata_mailer/project_creation.html.erb
@@ -29,7 +29,7 @@
           <dt>Departments</dt>
           <dd><%= @project.departments.join(", ") %></dd>
           <dt>Project Directory</dt>
-          <dd><%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:project_directory] %> </dd>
+          <dd><%= @project.project_directory %> </dd>
           <dt>Title</dt>
           <dd><%= @project.metadata[:title] %></dd>
           <dt>Description</dt>

--- a/app/views/tigerdata_mailer/project_creation.text.erb
+++ b/app/views/tigerdata_mailer/project_creation.text.erb
@@ -5,7 +5,7 @@ Requesting User Name: <%= @project.created_by_user.display_name %>
 Data Sponsor: <%= @project.metadata[:data_sponsor] %>
 Data Manager: <%= @project.metadata[:data_manager] %>
 Departments: <%= @project.departments.join(", ") %>
-Project Directory: <%= Rails.configuration.mediaflux["api_root_ns"] %>/<%= @project.metadata[:project_directory] %>
+Project Directory: <%= @project.project_directory %>
 Title: <%= @project.metadata[:title] %>
 Description: <%= @project.metadata[:description] %>
 Status: <%= @project.metadata[:status] %> 

--- a/docs/aterm_101.md
+++ b/docs/aterm_101.md
@@ -412,8 +412,8 @@ For example:
   ```
   session_id = User.first.mediaflux_session
   project = Project.first
-  project_name = ProjectMediaflux.safe_name(project.project_directory)
-  project_namespace = "#{Rails.configuration.mediaflux['api_root_ns']}/#{project_name}NS"
+  project_name = project.project_directory
+  project_namespace = "#{project_name}NS"
   store_name = Store.default(session_id: session_id).name
   namespace = Mediaflux::Http::NamespaceCreateRequest.new(namespace: project_namespace, description: "Namespace for project #{project.title}", store: store_name, session_token: session_id) 
  puts "\n\n #{namespace.xtoshell_xml}\n\n"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe ProjectsController do
         "<request xmlns:tigerdata=\"http://tigerdata.princeton.edu\">\n" \
         "  <service name=\"asset.create\">\n" \
         "    <args>\n" \
-        "      <name>#{project.project_directory}</name>\n" \
-        "      <namespace>/td-test-001/tigerdataNS/#{project.project_directory}NS</namespace>\n" \
+        "      <name>#{project.project_directory_short}</name>\n" \
+        "      <namespace>#{project.project_directory}NS</namespace>\n" \
         "      <meta>\n" \
         "        <tigerdata:project>\n" \
         "          <ProjectDirectory>#{project.project_directory}</ProjectDirectory>\n" \

--- a/spec/models/mediaflux/http/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_metadata_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Mediaflux::Http::AssetMetadataRequest, type: :model do
         expect(metadata[:total_file_count]).to eq("") # accumulators are not added to project when created
         expect(metadata[:quota_allocation]).to eq("") # quotas are not added to project when created
         expect(metadata[:project_id]).to eq("10.34770/tbd")
-        expect(metadata[:project_directory]).to eq(valid_project.metadata_json["project_directory"])
+        expect(metadata[:project_directory]).to eq(valid_project.project_directory)
       end
     end
   end

--- a/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::Http::NamespaceDestroyRequest, type: :model, connect_to_mediaflux: true do
   let(:valid_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd") }
-  let(:namespace) { "#{valid_project.project_directory}NS".strip.gsub(/[^A-Za-z\d]/, "-") }
+  let(:namespace) { "#{valid_project.project_directory_short}NS".strip.gsub(/[^A-Za-z\d]/, "-") }
   let(:sponsor_user) { FactoryBot.create(:project_sponsor) }
   let(:session_id) { sponsor_user.mediaflux_session }
   it "deletes a namespace and everything inside of it" do

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -132,12 +132,4 @@ RSpec.describe ProjectMediaflux, type: :model, stub_mediaflux: true do
       end
     end
   end
-
-  describe "#safe_name" do
-    it "handles special characters" do
-      expect(described_class.safe_name("hello-world")).to eq "hello-world"
-      expect(described_class.safe_name(" hello world 123")).to eq "hello-world-123"
-      expect(described_class.safe_name("/hello/world")).to eq "-hello-world"
-    end
-  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -178,4 +178,39 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
       expect(project).not_to be_changed # the method saves the id to the database
     end
   end
+
+  describe "#project_directory" do
+    it "includes the full path" do
+      project = FactoryBot.create(:project)
+      expect(project.project_directory).to eq("#{Rails.configuration.mediaflux['api_root_ns']}/#{project.metadata_json['project_directory']}")
+    end
+
+    it "does not include the default path if a path is already included" do
+      project = FactoryBot.create(:project, project_directory: "/123/abc/directory")
+      expect(project.project_directory).to eq("/123/abc/directory")
+    end
+
+    it "makes sure the directory is safe" do
+      project = FactoryBot.create(:project, project_directory: "directory?")
+      expect(project.project_directory).to eq("#{Rails.configuration.mediaflux['api_root_ns']}/directory-")
+      project = FactoryBot.create(:project, project_directory: "direc tory ")
+      expect(project.project_directory).to eq("#{Rails.configuration.mediaflux['api_root_ns']}/direc-tory")
+      project = FactoryBot.create(:project, project_directory: "direc/tory/")
+      expect(project.project_directory).to eq("#{Rails.configuration.mediaflux['api_root_ns']}/direc-tory-")
+    end
+  end
+
+  describe "#project_directory_short" do
+    it "does not include the full path" do
+      project = FactoryBot.create(:project, project_directory: "/123/abc/directory")
+      expect(project.project_directory_short).to eq("directory")
+    end
+  end
+
+  describe "#project_directory_parent_path" do
+    it "does notinclude the directory" do
+      project = FactoryBot.create(:project, project_directory: "/123/abc/directory")
+      expect(project.project_directory_parent_path).to eq("/123/abc")
+    end
+  end
 end


### PR DESCRIPTION
This will allow us to update to what is in mediaflux in the future, not just rely on the default path