### PR TITLE
Add storage unit dropdown to project approval form

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -291,10 +291,10 @@
   }
   button{
     min-width: 160px;
-    min-height: 38px
+    min-height: 38px;
   }
   a{
     min-width: 160px;
-    min-height: 38px
+    min-height: 38px;
   }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -126,7 +126,7 @@ class ProjectsController < ApplicationController
         project_directory: project_params["project_directory"],
         storage_capacity: {"size"=>{"approved"=>project_params["storage_capacity"].to_i, 
                             "requested"=>project.metadata[:storage_capacity][:size][:requested]}, 
-                            "unit"=>{"approved"=>"GB", "requested"=>"GB"}},
+                            "unit"=>{"approved"=>project_params["storage_unit"], "requested"=>"GB"}},
         approval_note: {
           note_by: current_user.uid,
           note_date_time: Time.current.in_time_zone("America/New_York").iso8601,

--- a/app/views/projects/_approve_form.html.erb
+++ b/app/views/projects/_approve_form.html.erb
@@ -1,7 +1,7 @@
 <%= render 'form_errors' %>
 <%= render 'data_list' %>
 
-<div class="container" id="approve">
+<div class="container">
   <div class="field">
     <label for="project_directory" class="form-label">Confirm Project Directory</label>
     <input class="form-directory" type="text" name="project_directory-prefix" disabled readonly value= <%= Rails.configuration.mediaflux["api_root_ns"] %>></input> /  
@@ -9,7 +9,14 @@
   </div>
   <div class="field">
     <label for="storage_capacity" class="form-label">Confirm Storage Capacity</label>
-    <input class="form-control" type="number" min="1" name="storage_capacity" required placeholder=<%= "#{@project.metadata[:storage_capacity][:size][:requested]}"%>>GB</input> 
+    <input class="form-control" type="number" min="1" name="storage_capacity" id="storage_capacity" required placeholder=<%= "#{@project.metadata[:storage_capacity][:size][:requested]}"%>></input>
+    <label for="storage_unit" class="form-label" hidden>Storage Unit</label>
+    <select class="form-dropdown" name="storage_unit" id="storage_unit" required>
+      <option disabled selected value> -- unit -- </option>
+      <option value="GB">GB</option>
+      <option value="TB">TB</option>
+      <option value="PB">PB</option>
+    </select>
   </div>
   <div class="field">
     <label for="mediaflux_id" class="form-label">Collection ID</label>
@@ -25,7 +32,7 @@
   </div>
   <div class="field">
     <label for="event_note" class="form-label">Event Note</label>
-    <select class="form-dropdown" name="event_note" id="Event Note">
+    <select class="form-dropdown" name="event_note" id="event_note">
       <option disabled selected value> -- select an option -- </option>
       <option value="Quota">Quota</option>
       <option value="Tier">Tier</option>
@@ -34,8 +41,8 @@
     <label for="event_note_message" class="form-label">Message</label>
     <input class="form-message" type="text" name="event_note_message"> </input>
   </div>
-    <div class="controls">
-      <button type="submit" class="btn btn-primary">Approve</button>
-      <%= link_to "Cancel", root_path, class: "btn btn-secondary" %>
-    </div>
+  <div class="controls">
+    <button type="submit" class="btn btn-primary">Approve</button>
+    <%= link_to "Cancel", root_path, class: "btn btn-secondary" %>
+  </div>
 </div>

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -440,6 +440,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       expect(page).to have_content("Project Approval: #{project.metadata_json['title']}")
 
       fill_in "storage_capacity", with: 500
+      select "GB", from: "storage_unit"
       fill_in "project_directory", with: project.metadata_json["project_directory"]
       fill_in "mediaflux_id", with: mediaflux_id
       select "Other", from: "event_note"
@@ -453,7 +454,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       # redirects the user to the project show page
     end
 
-    it "redirects the user to the revision request confirmation page upon submission" do
+    it "redirects the user to the project approval confirmation page upon submission" do
       sign_in sysadmin_user
       expect(project.mediaflux_id).to be nil
       expect(project.metadata_json["status"]).to eq Project::PENDING_STATUS
@@ -462,6 +463,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
       expect(page).to have_content("Project Approval: #{project.metadata_json['title']}")
 
       fill_in "storage_capacity", with: 500
+      select "GB", from: "storage_unit"
       fill_in "project_directory", with: project.metadata_json["project_directory"]
       fill_in "mediaflux_id", with: mediaflux_id
       select "Other", from: "event_note"


### PR DESCRIPTION
turned the static storage unit into a required dropdown
closes #696 