### PR TITLE
Raise an error when attempting to destroy an invalid namespace

### DIFF
--- a/app/models/mediaflux/http/namespace_destroy_request.rb
+++ b/app/models/mediaflux/http/namespace_destroy_request.rb
@@ -20,6 +20,7 @@ module Mediaflux
         resolve
         if error?
           response_error
+          raise(StandardError, "call to service 'asset.namespace.hard.destroy' failed: The namespace #{namespace} does not exist or is not accessible")
         end
       end
 

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -32,9 +32,6 @@ class ProjectMediaflux
     prepare_parent_collection(project_parent:, session_id:)
     create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: session_id, namespace: project_namespace, name: project.project_directory_short, tigerdata_values: tigerdata_values,
                                                              xml_namespace: xml_namespace, pid: project_parent)
-
-          #TODO: custom exception class raised for metadata issues. This would allow us to see them in Honeybadger and know how often they're happening. 
-          #All exceptions that are raised should include the current expected metadata schema version number, as well as what metadata is missing.
     id = create_request.id
     if id.blank?
       response_error = create_request.response_error

--- a/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Mediaflux::Http::NamespaceDestroyRequest, type: :model, connect_t
       namespace_list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
       namespace_names = namespace_list.pluck(:name)
       expect(namespace_names).not_to include(namespace)
-      
+
       # Should raise an error when attempting to destroy a namespace that does not exist
-      expect {
-          described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
-        }.to raise_error do |error|
-          expect(error).to be_a(StandardError)
-          expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace /td-test-001/tigerdataNS/#{namespace} does not exist or is not accessible")
-        end
+      expect do
+        described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
+      end.to raise_error do |error|
+        expect(error).to be_a(StandardError)
+        expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace /td-test-001/tigerdataNS/#{namespace} does not exist or is not accessible")
+      end
     end
   end
 end

--- a/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Mediaflux::Http::NamespaceDestroyRequest, type: :model, connect_t
       expect(namespace_names).not_to include(namespace)
 
       # Should raise an error when attempting to destroy a namespace that does not exist
-      expect do
-        described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
-      end.to raise_error do |error|
+      expect { described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy }.to raise_error do |error|
         expect(error).to be_a(StandardError)
         expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace /td-test-001/tigerdataNS/#{namespace} does not exist or is not accessible")
       end

--- a/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/http/namespace_destroy_request_spec.rb
@@ -6,19 +6,27 @@ RSpec.describe Mediaflux::Http::NamespaceDestroyRequest, type: :model, connect_t
   let(:namespace) { "#{valid_project.project_directory_short}NS".strip.gsub(/[^A-Za-z\d]/, "-") }
   let(:sponsor_user) { FactoryBot.create(:project_sponsor) }
   let(:session_id) { sponsor_user.mediaflux_session }
-  it "deletes a namespace and everything inside of it" do
-    mediaflux_id = valid_project.save_in_mediaflux(session_id: session_id)
-    expect(mediaflux_id).not_to be_nil
-    namespace_list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
-    namespace_names = namespace_list.pluck(:name)
-    expect(namespace_names).to include(namespace)
+  context "when a namespace exists" do
+    it "deletes a namespace and everything inside of it" do
+      mediaflux_id = valid_project.save_in_mediaflux(session_id: session_id)
+      expect(mediaflux_id).not_to be_nil
+      namespace_list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
+      namespace_names = namespace_list.pluck(:name)
+      expect(namespace_names).to include(namespace)
 
-    # Destroy the namespace of the project and everything in it
-    described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
-    namespace_list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
-    namespace_names = namespace_list.pluck(:name)
-    expect(namespace_names).not_to include(namespace)
-    response = described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
-    expect(response[:message]).to include("The namespace '/td-test-001/tigerdataNS/#{namespace}' does not exist or is not accessible")
+      # Destroy the namespace of the project and everything in it
+      described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
+      namespace_list = Mediaflux::Http::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
+      namespace_names = namespace_list.pluck(:name)
+      expect(namespace_names).not_to include(namespace)
+      
+      # Should raise an error when attempting to destroy a namespace that does not exist
+      expect {
+          described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
+        }.to raise_error do |error|
+          expect(error).to be_a(StandardError)
+          expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace /td-test-001/tigerdataNS/#{namespace} does not exist or is not accessible")
+        end
+    end
   end
 end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe ProjectMediaflux, type: :model do
         expect {
           ProjectMediaflux.create!(project: incomplete_project, session_id: session_token)
         }.to raise_error do |error|
-          expect([MediafluxDuplicateNamespaceError, StandardError, RuntimeError]).to include(error.class)
+          expect(error).to be_a(StandardError)
+          expect(error.message).to include("call to service 'asset.create' failed: XPath tigerdata:project/ProjectID is invalid: missing value")
         end
       end
     end

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -19,8 +19,8 @@ RSpec.configure do |config|
       ).destroy
     end
   rescue StandardError => namespace_error
-    message = "Bypassing pre-test cleanup error"
-    Rails.logger.error(message, namespace_error)
+    message = "Bypassing pre-test cleanup error, #{namespace_error.message}"
+    Rails.logger.error(message)
   end
 
   config.after(:each) do |ex|

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
     end
   rescue StandardError => namespace_error
     message = "Bypassing pre-test cleanup error"
-    Rails.logger.error(message)
+    Rails.logger.error(message, namespace_error)
   end
 
   config.after(:each) do |ex|

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -18,6 +18,10 @@ RSpec.configure do |config|
         namespace: Rails.configuration.mediaflux[:api_root_ns]
       ).destroy
     end
+    rescue StandardError => namespace_error
+      message = "Bypassing pre-test cleanup error"
+      Rails.logger.error(message)
+    
   end
 
   config.after(:each) do |ex|

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -18,10 +18,9 @@ RSpec.configure do |config|
         namespace: Rails.configuration.mediaflux[:api_root_ns]
       ).destroy
     end
-    rescue StandardError => namespace_error
-      message = "Bypassing pre-test cleanup error"
-      Rails.logger.error(message)
-    
+  rescue StandardError => namespace_error
+    message = "Bypassing pre-test cleanup error"
+    Rails.logger.error(message)
   end
 
   config.after(:each) do |ex|


### PR DESCRIPTION
- raising an error when attempting to destroy a namespace that does not exist
- testing namespace destroy on an invalid namespace
- allowing connect_to_mediaflux support spec to continue despite encountering a namespace destroy error
closes #692 