### PR TITLE
Initializing a quota for a project when it is created in mediaflux

### DIFF
--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -53,6 +53,7 @@ class ProjectMediaflux
     project.mediaflux_id = id
     project.save!
     self.create_accumulators(mediaflux_project_id: id, session_id: session_id)
+    self.create_quota(project: project, mediaflux_project_id: id, session_id: session_id)
     id
   end
 
@@ -75,6 +76,17 @@ class ProjectMediaflux
       type: "content.all.size"
       )
     accum_size.resolve
+  end
+
+  def self.create_quota(project:, mediaflux_project_id:, session_id:)
+    #TODO: SHOULD WE CREATE A PROJECT USING REQUESTED VALUES OR APPROVED VALUES?
+    allocation = project.metadata_json["storage_capacity"]["size"]["requested"].to_s << " " << project.metadata_json["storage_capacity"]["unit"]["requested"]
+    quota_request = Mediaflux::Http::CreateCollectionQuotaRequest.new(
+      session_token: session_id,
+      collection: mediaflux_project_id,
+      allocation: allocation
+    )
+    quota_request.resolve
   end
 
   def self.update(project:, session_id:)

--- a/spec/models/mediaflux/http/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_metadata_request_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Mediaflux::Http::AssetMetadataRequest, type: :model do
         expect(metadata[:type]).to eq("application/arc-asset-collection")
         expect(metadata[:size]).to eq("0 bytes")
         expect(metadata[:total_file_count]).to eq("0")
-        expect(metadata[:quota_allocation]).to eq("") # quotas are not added to project when created
+        expect(metadata[:quota_allocation]).to eq("500 GB")
         expect(metadata[:project_id]).to eq("10.34770/tbd")
         expect(metadata[:project_directory]).to eq(valid_project.project_directory)
       end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ProjectMediaflux, type: :model do
             id: project.mediaflux_id
             ).metadata
           expect(metadata[:quota_allocation]).not_to be_empty
+          expect(metadata[:quota_allocation]).to eq("500 GB")
         end
       end
 

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -40,13 +40,24 @@ RSpec.describe ProjectMediaflux, type: :model do
         it "adds accumulators when it creates a project in mediaflux" do
           project = FactoryBot.create(:project_with_doi)
           described_class.create!(project: project, session_id: current_user.mediaflux_session)
-          # project.save_in_mediaflux(session_id: current_user.mediaflux_session)
           metadata = Mediaflux::Http::AssetMetadataRequest.new(
             session_token: current_user.mediaflux_session, 
             id: project.mediaflux_id
             ).metadata
           expect(metadata[:accumulators]).not_to be_empty
           expect(metadata[:accumulators].size).to eq 2
+        end
+      end
+
+      describe "quota", connect_to_mediaflux: true do
+        it "adds a quota when it creates a project in mediaflux" do
+          project = FactoryBot.create(:project_with_doi)
+          described_class.create!(project: project, session_id: current_user.mediaflux_session)
+          metadata = Mediaflux::Http::AssetMetadataRequest.new(
+            session_token: current_user.mediaflux_session, 
+            id: project.mediaflux_id
+            ).metadata
+          expect(metadata[:quota_allocation]).not_to be_empty
         end
       end
 


### PR DESCRIPTION
closes #685 