### PR TITLE
Status highlight displays based on project status

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -90,6 +90,7 @@ class ProjectsController < ApplicationController
     @provenance_events = project.provenance_events.where.not(event_type: ProvenanceEvent::STATUS_UPDATE_EVENT_TYPE)
     @project_status = project.metadata[:status]
 
+    @pending_status = Project::PENDING_STATUS
     @approved_status = Project::APPROVED_STATUS
     @eligible_editor = eligible_editor?
     @project_eligible_to_edit = true if @project_status == @approved_status && eligible_editor?

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,7 +10,7 @@ Project Details:
   </div>
 <% end %>
 
-<% if !@project.in_mediaflux? %>
+<% if @project.status == @pending_status %>
   <div class="alert alert-warning" role="alert">
     <dl>
     <dt>Status</dt> <dd><%=@project_status%></dd>

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
 
             expect(page).to have_content(project_in_mediaflux.title)
             expect(page).not_to have_content(pending_text)
+            expect(page).to have_css ".alert-success"
             expect(page).to have_selector(:link_or_button, "Edit") # button next to role and description heading
             expect(page).to have_selector(:link_or_button, "Review Contents")
             expect(page).to have_selector(:link_or_button, "Withdraw Project Request")
@@ -73,6 +74,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
             visit "/projects/#{project_not_in_mediaflux.id}"
             expect(page).to have_content(project_not_in_mediaflux.title)
             expect(page).to have_content(pending_text)
+            expect(page).to have_css ".alert-warning"
             expect(page).not_to have_link("Edit")
             expect(page).to have_selector(:link_or_button, "Review Contents")
             click_on("Return to Dashboard")
@@ -87,6 +89,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
             visit "/projects/#{project_not_in_mediaflux.id}"
             expect(page).to have_content(project_not_in_mediaflux.title)
             expect(page).to have_content(pending_text)
+            expect(page).to have_css ".alert-warning"
             expect(page).not_to have_link("Edit")
             expect(page).to have_selector(:link_or_button, "Approve Project")
             expect(page).to have_selector(:link_or_button, "Deny Project")


### PR DESCRIPTION
Refactoring the status highlight to display based on the projects current status, instead of whether or not it is in mediaflux.