### PR TITLE
Grant trainer emulation permissions

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -60,26 +60,38 @@
   }
 }
 
-#dashboard-projects {
-  @include dashboard-component;
-  min-width: 40em;
- 
-  .btn-dark {
-    margin-left: 0.5em;
-    margin-bottom: 0.5em;
+#welcome {
+  .emulation {
+    display: inline-flex;
   }
+  
+  #emulation_bar {
+    margin-left: 5px
+  }
+
+  #dashboard-projects {
+    @include dashboard-component;
+    min-width: 40em;
+  
+    .btn-dark {
+      margin-left: 0.5em;
+      margin-bottom: 0.5em;
+    }
+  }
+
+  #dashboard-activity{
+    @include dashboard-component;
+    min-height: 15em;
+  }
+
+  #dashboard-pending{
+    @include dashboard-component;
+    margin-top: 1em;
+    min-width: 30em;
+  }
+
 }
 
-#dashboard-activity{
-  @include dashboard-component;
-  min-height: 15em;
-}
-
-#dashboard-pending{
-  @include dashboard-component;
-  margin-top: 1em;
-  min-width: 30em;
-}
 
 #show{
   .pending-project {

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -9,6 +9,7 @@ class WelcomeController < ApplicationController
     @my_projects_count = @sponsored_projects.count + @managed_projects.count + @data_user_projects.count
     @pending_projects = Project.pending_projects
     @approved_projects = Project.approved_projects
+    @eligible_data_user = true if !current_user.eligible_sponsor? && !current_user.eligible_manager?
 
     @my_jobs = current_user.user_jobs
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,15 +12,14 @@ class WelcomeController < ApplicationController
     @eligible_data_user = true if !current_user.eligible_sponsor? && !current_user.eligible_manager?
 
     @my_jobs = current_user.user_jobs
-    
+
     User.emulate(user: current_user, session_data: session)
   end
 
   def help; end
 
-  private
-    # def session_active?
-    #   User.reset_trainer
-    #   main_app.destroy_user_session
-    # end;
+  # def session_active?
+  #   User.reset_trainer
+  #   main_app.destroy_user_session
+  # end;
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,7 +12,15 @@ class WelcomeController < ApplicationController
     @eligible_data_user = true if !current_user.eligible_sponsor? && !current_user.eligible_manager?
 
     @my_jobs = current_user.user_jobs
+    
+    User.emulate(user: current_user, session_data: session)
   end
 
   def help; end
+
+  private
+    # def session_active?
+    #   User.reset_trainer
+    #   main_app.destroy_user_session
+    # end;
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,22 +13,22 @@ class User < ApplicationRecord
   def self.emulate(user:, session_data:, role:)
     return if Rails.env.production?
     return unless user.trainer
-    
-    #TODO: FIGURE OUT HOW TO MAKE EMULATION TEMPORARY AND TIED TO A SINGLE SESSION
+
+    # TODO: FIGURE OUT HOW TO MAKE EMULATION TEMPORARY AND TIED TO A SINGLE SESSION
     if role == "sponsor"
       user.eligible_sponsor = true
     elsif role == "manager"
-      user.eligible_manager = true 
+      user.eligible_manager = true
     elsif role == "sysadmin"
-      user.sysadmin = true 
+      user.sysadmin = true
     else
-      user.reset_trainer()
+      user.reset_trainer
     end
   end
 
-  def reset_trainer()
-    user = user 
-    if user.eligible_sponsor? or user.eligible_manager?
+  def reset_trainer
+    user = user
+    if user.eligible_sponsor? || user.eligible_manager?
       user.eligible_sponsor = false
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,29 @@ class User < ApplicationRecord
 
   USER_REGISTRATION_LIST = Rails.root.join("data", "user_registration_list_#{Rails.env}.csv")
 
+  def self.emulate(user:, session_data:, role:)
+    return if Rails.env.production?
+    return unless user.trainer
+    
+    #TODO: FIGURE OUT HOW TO MAKE EMULATION TEMPORARY AND TIED TO A SINGLE SESSION
+    if role == "sponsor"
+      user.eligible_sponsor = true
+    elsif role == "manager"
+      user.eligible_manager = true 
+    elsif role == "sysadmin"
+      user.sysadmin = true 
+    else
+      user.reset_trainer()
+    end
+  end
+
+  def reset_trainer()
+    user = user 
+    if user.eligible_sponsor? or user.eligible_manager?
+      user.eligible_sponsor = false
+    end
+  end
+
   def self.from_cas(access_token)
     user = User.find_by(provider: access_token.provider, uid: access_token.uid)
     if user.present? && user.given_name.nil? # fix any users that do not have the name information loaded

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,97 +1,110 @@
-<% unless current_user %>
-  <h1>Welcome to TigerData</h1>
-  Please log in.
-<% else %>
-  <h1>Welcome, <%= current_user.given_name %>!</h1>
-  <div style="display: inline-flex">
-    <% if !current_user.eligible_sysadmin? or current_user.superuser? %>
-    <div id="dashboard-projects">
-      <h1>My Projects</h1>
-      <% if @sponsored_projects.size > 0 %>
-        <h2>Sponsored by Me</h2>
-        <ul class="project-list">
-          <% @sponsored_projects.each do |project| %>
-            <li><%= link_to(project.title, project) %> </li>
+<div id="welcome">
+  <% unless current_user %>
+    <h1>Welcome to TigerData</h1>
+    Please log in.
+  <% else %>
+    <h1>Welcome, <%= current_user.given_name %>!</h1>
+    <% if !Rails.env.production? && current_user.trainer?%>
+      <h3 class="emulation">View As</h4>
+      <select class="emulation" name="emulation_bar" id="emulation_bar" required>
+          <option disabled="disabled" <%= "selected" if current_user.trainer?%>>Trainer</option>
+          <option value="Eligible Data Sponsor" <%= "selected" if current_user.eligible_sponsor%>>Eligible Data Sponsor</option>
+          <option value="Eligible Data Manager" <%= "selected" if current_user.eligible_manager%>>Eligible Data Manager</option>
+          <option value="Eligible Data User" <%= "selected" if @eligible_sysadmin%>>Eligible Data User</option>
+          <option value="System Administrator" <%= "selected" if current_user.sysadmin%>>System Administrator</option>
+          <option value="Return to Self">Return to Self</option>
+      </select>
+    <% end %>
+    <div style="display: inline-flex">
+      <% if !current_user.eligible_sysadmin? or current_user.superuser? %>
+      <div id="dashboard-projects">
+        <h1>My Projects</h1>
+        <% if @sponsored_projects.size > 0 %>
+          <h2>Sponsored by Me</h2>
+          <ul class="project-list">
+            <% @sponsored_projects.each do |project| %>
+              <li><%= link_to(project.title, project) %> </li>
+            <%end%>
+          </ul>
+        <% end %>
+        <% if @managed_projects.size > 0 %>
+          <h2>Managed by Me</h2>
+          <ul class="project-list">
+            <% @managed_projects.each do |project| %>
+              <li><%= link_to(project.title, project) %> </li>
+            <%end%>
+          </ul>
+        <% end %>
+        <% if @data_user_projects.size > 0 %>
+          <h2>Shared with Me</h2>
+          <ul class="project-list">
+            <% @data_user_projects.each do |project| %>
+              <li><%= link_to(project.title, project) %> </li>
+            <%end%>
+          </ul>
+        <% end %>
+        <div>
+          <br/>
+          <%if current_user.eligible_sponsor?%>
+            <%= link_to "New Project", new_project_path(), class: "btn btn-dark btn-sm" %>
           <%end%>
-        </ul>
-      <% end %>
-      <% if @managed_projects.size > 0 %>
-        <h2>Managed by Me</h2>
-        <ul class="project-list">
-          <% @managed_projects.each do |project| %>
-            <li><%= link_to(project.title, project) %> </li>
-          <%end%>
-        </ul>
-      <% end %>
-      <% if @data_user_projects.size > 0 %>
-        <h2>Shared with Me</h2>
-        <ul class="project-list">
-          <% @data_user_projects.each do |project| %>
-            <li><%= link_to(project.title, project) %> </li>
-          <%end%>
-        </ul>
-      <% end %>
-      <div>
-        <br/>
-        <%if current_user.eligible_sponsor?%>
-          <%= link_to "New Project", new_project_path(), class: "btn btn-dark btn-sm" %>
-        <%end%>
+        </div>
       </div>
+      <div id="dashboard-activity">
+          <h2>Recent Activity</h2>
+          <% if !@my_jobs.empty? %>
+          <ul>
+            <% @my_jobs.each do |job| %>
+              <li>
+                <%= job.title %>
+                <% if job.complete? %>
+                  (<%= link_to("download", project_file_list_download_path(job_id: job.job_id, target: "_blank")) %>)
+                <% end %>
+                <ul>
+                  <li><%= job.description %></li>
+                  <% if job.completed_at.present? %>
+                    <li><%= job.completion %></li>
+                  <% end %>
+                </ul>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+      <% end %>
     </div>
-    <div id="dashboard-activity">
-        <h2>Recent Activity</h2>
-        <% if !@my_jobs.empty? %>
-        <ul>
-          <% @my_jobs.each do |job| %>
-            <li>
-              <%= job.title %>
-              <% if job.complete? %>
-                (<%= link_to("download", project_file_list_download_path(job_id: job.job_id, target: "_blank")) %>)
-              <% end %>
-              <ul>
-                <li><%= job.description %></li>
-                <% if job.completed_at.present? %>
-                  <li><%= job.completion %></li>
+    <div style="display: inline-flex">
+      <% if current_user.eligible_sysadmin?%>
+        <div id="dashboard-pending">
+          <h1>Project Administration</h1>
+            <h4>Pending Projects</h4>
+            <% if !@pending_projects.empty? %>
+              <ul class="project-list">
+                <% @pending_projects.each do |project| %>
+                  <li>
+                    <%= link_to(project.title, project) %>
+                  </li>
                 <% end %>
               </ul>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+            <% else %>
+              <p> (none) </p>
+            <% end %>
+            <h4>Recently Approved Projects</h4>
+            <% if !@approved_projects.empty? %>
+              <table class="sysadmin-list">
+                <% @approved_projects.each_with_index do |project, index| %>
+                  <% @row_css = index < 5 ? "visible-row top-section" : "invisible-row bottom-section" %>
+                  <tr class ="<%=@row_css%>">
+                    <td><%= link_to(project.title, project) %> </td>
+                  </tr>
+                <% end %>
+              </table>
+              <button id="show-more-sysadmin" type="button" class="btn btn-dark">Show More</button>
+            <% else %>
+              <p> (none) </p>
+            <% end %>
+        </div>
+      <%end%>
     </div>
     <% end %>
   </div>
-  <div style="display: inline-flex">
-    <% if current_user.eligible_sysadmin?%>
-      <div id="dashboard-pending">
-        <h1>Project Administration</h1>
-          <h4>Pending Projects</h4>
-          <% if !@pending_projects.empty? %>
-            <ul class="project-list">
-              <% @pending_projects.each do |project| %>
-                <li>
-                  <%= link_to(project.title, project) %>
-                </li>
-              <% end %>
-            </ul>
-          <% else %>
-            <p> (none) </p>
-          <% end %>
-          <h4>Recently Approved Projects</h4>
-          <% if !@approved_projects.empty? %>
-            <table class="sysadmin-list">
-              <% @approved_projects.each_with_index do |project, index| %>
-                <% @row_css = index < 5 ? "visible-row top-section" : "invisible-row bottom-section" %>
-                <tr class ="<%=@row_css%>">
-                  <td><%= link_to(project.title, project) %> </td>
-                </tr>
-              <% end %>
-            </table>
-            <button id="show-more-sysadmin" type="button" class="btn btn-dark">Show More</button>
-          <% else %>
-            <p> (none) </p>
-          <% end %>
-      </div>
-    <%end%>
-  </div>
-  <% end %>

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -106,5 +106,16 @@ RSpec.describe "WelcomeController", stub_mediaflux: true do
         expect(page).to have_content("Approved Projects")
       end
     end
+
+    context "for tester-trainers" do 
+      it "shows the emulation bar" do 
+        sign_in current_user
+        current_user.trainer = true
+        current_user.save!
+        visit "/"
+        expect(page).to have_content("View As")
+        expect(page).to have_select("emulation_bar")
+      end
+    end
   end
 end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe "WelcomeController", stub_mediaflux: true do
       end
     end
 
-    context "for tester-trainers" do 
-      it "shows the emulation bar" do 
+    context "for tester-trainers" do
+      it "shows the emulation bar" do
         sign_in current_user
         current_user.trainer = true
         current_user.save!


### PR DESCRIPTION
Giving tester-trainers the ability to emulate other roles, and navigate Tigerdata as those roles. Emulation only lasts the length of the session, after which the trainer gets their roles reverted to their original state.

closes #619 
unblocks #620 