### PR TITLE
Updating AssetCreateRequest to only create collections

### DIFF
--- a/app/models/mediaflux/http/asset_create_request.rb
+++ b/app/models/mediaflux/http/asset_create_request.rb
@@ -7,16 +7,14 @@ module Mediaflux
       # Constructor
       # @param session_token [String] the API token for the authenticated session
       # @param name [String] Name of the Asset
-      # @param collection [Boolean] create a collection asset if true
       # @param namespace [String] Optional Parent namespace for the asset to be created in
       # @param pid [String] Optional Parent collection id (use this or a namespace not both)
       # @param tigerdata_values [Hash] Optional parameter for the tigerdata metdata to be applied to the new asset in the meta field
       # @param xml_namespace [String]
-      def initialize(session_token:, namespace: nil, name:, collection: true, tigerdata_values: nil, xml_namespace: nil, xml_namespace_uri: nil, pid: nil)
+      def initialize(session_token:, namespace: nil, name:, tigerdata_values: nil, xml_namespace: nil, xml_namespace_uri: nil, pid: nil)
         super(session_token: session_token)
         @namespace = namespace
         @asset_name = name
-        @collection = collection
         @tigerdata_values = tigerdata_values
         @xml_namespace = xml_namespace || self.class.default_xml_namespace
         @xml_namespace_uri = xml_namespace_uri || self.class.default_xml_namespace_uri
@@ -61,12 +59,11 @@ module Mediaflux
         end
 
         def collection_xml(xml)
-          return unless collection
           xml.collection do
             xml.parent.set_attribute("cascade-contained-asset-index", true)
             xml.parent.set_attribute("contained-asset-index", true)
             xml.parent.set_attribute("unique-name-index", true)
-            xml.text(collection)
+            xml.text(true)
           end
           xml.type "application/arc-asset-collection"
         end

--- a/app/models/mediaflux/http/asset_metadata_request.rb
+++ b/app/models/mediaflux/http/asset_metadata_request.rb
@@ -69,6 +69,7 @@ module Mediaflux
         def parse(asset)
           {
             id: asset.xpath("./@id").text,
+            name: asset.xpath("./name").text,
             creator: asset.xpath("./creator/user").text,
             description: asset.xpath("./description").text,
             collection: asset.xpath("./@collection")&.text == "true",
@@ -76,20 +77,25 @@ module Mediaflux
             type: asset.xpath("./type").text,
             namespace: asset.xpath("./namespace").text,
             accumulators: asset.xpath("./collection/accumulator/value") # list of accumulator values in xml format. Can parse further through xpath
-          }.merge(parse_project(asset))
+          }.merge(parse_project(asset.xpath("//tigerdata:project", "tigerdata" => "tigerdata").first))
         end
 
-        def parse_project(asset)
-          project = asset.xpath("//tigerdata:project", "tigerdata" => "tigerdata").first
-          if project.present?
-            {
-              project_id: project.xpath("./ProjectID").text,
-              project_directory: project.xpath("./ProjectDirectory").text,
-              submission: parse_submission(project)
-            }
-          else
-            {}
-          end
+        def parse_project(project)
+          return {} if project.blank?
+          {
+            created_by: project.xpath("./CreatedBy").text,
+            created_on: project.xpath("./CreatedOn").text,
+            description: project.xpath("./Description").text,
+            data_sponsor: project.xpath("./DataSponsor").text,
+            data_manager: project.xpath("./DataManager").text,
+            departments: project.xpath("./Department").children.map(&:text),
+            project_directory: project.xpath("./ProjectDirectory").text,
+            project_id: project.xpath("./ProjectID").text,
+            ro_users: project.xpath("./DataUser[@ReadOnly]").map(&:text),
+            rw_users: project.xpath("./DataUser[not(@ReadOnly)]").map(&:text),
+            submission: parse_submission(project),
+            title: project.xpath("./Title").text
+          }
         end
 
         def parse_submission(project)

--- a/spec/models/mediaflux/http/asset_create_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_create_request_spec.rb
@@ -17,60 +17,31 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
         .to_return(status: 200, body: create_response, headers: {})
     end
 
-    it "parses a metadata response" do
-      create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", collection: false)
-      expect(create_request.id).to eq("1068")
-      expect(a_request(:post, mediflux_url).with do |req| 
-        req.body.include?("<name>testasset</name>")
-      end
-      ).to have_been_made
-    end
+    it "sends the metadata to the server", connect_to_mediaflux: true do
+      data_user_ro = FactoryBot.create :user
+      data_user_rw = FactoryBot.create :user
+      session_id =  data_user_ro.mediaflux_session
 
-    context "an asset with metadata" do
-      before do
-        stub_request(:post, mediflux_url).to_return(status: 200, body: create_response, headers: {})
-      end
-      it "sends the metadata to the server" do
-        data_user_ro = FactoryBot.create :user
-        data_user_rw = FactoryBot.create :user
-        created_on = Time.current.in_time_zone("America/New_York").iso8601
-        project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on
-        tigerdata_values = ProjectMediaflux.project_values(project:)
-        create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", collection: false, tigerdata_values: tigerdata_values)
-        expect(create_request.id).to eq("1068")
-        puts "created on #{project.metadata[:created_on]}"
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<name>testasset</name>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<Title>#{project.metadata[:title]}</Title>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<Description>#{project.metadata[:description]}</Description>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<DataManager>#{project.metadata[:data_manager]}</DataManager>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<Department>#{project.metadata[:departments].first}</Department>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<Department>#{project.metadata[:departments].last}</Department>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<CreatedOn>#{MediafluxTime.format_date_for_mediaflux(created_on)}</CreatedOn>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<CreatedBy>#{project.metadata[:created_by]}</CreatedBy>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<DataUser ReadOnly=\"true\">#{data_user_ro.uid}</DataUser>") }).to have_been_made
-        expect(a_request(:post, mediflux_url).with { |req| req.body.include?("<DataUser>#{data_user_rw.uid}</DataUser>") }).to have_been_made
-      end
-    end
-
-    context "A collection" do
-      before do
-        stub_request(:post, mediflux_url)
-          .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.create\" session=\"secretsecret/2/31\">\n    "\
-                      "<args>\n      <name>testasset</name>\n      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n"\
-                      "      <type>application/arc-asset-collection</type>\n    </args>\n  </service>\n</request>\n")
-          .to_return(status: 200, body: create_response, headers: {})
-      end
-
-      it "parses a metadata response" do
-        create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", collection: true)
-        expect(create_request.id).to eq("1068")
-        expect(a_request(:post, mediflux_url).with do |req| 
-            req.body.include?("<name>testasset</name>") && 
-            req.body.include?("<type>application/arc-asset-collection</type>")
-          end
-        ).to have_been_made
-      end
+      created_on = Time.current.in_time_zone("America/New_York").iso8601
+      project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on, project_id: "abc/123"
+      tigerdata_values = ProjectMediaflux.project_values(project:)
+      create_request = described_class.new(session_token: session_id, name: "testasset", tigerdata_values: tigerdata_values, namespace: Rails.configuration.mediaflux[:api_root_ns])
+      expect(create_request.response_error).to be_blank
+      expect(create_request.id).not_to be_blank
+      req = Mediaflux::Http::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
+      metadata  = req.metadata
+      
+      puts "created on #{project.metadata[:created_on]}"
+      expect(metadata[:name]).to eq("testasset")
+      expect(metadata[:title]).to eq(project.metadata[:title])
+      expect(metadata[:description]).to eq(project.metadata[:description])
+      expect(metadata[:data_sponsor]).to eq(project.metadata[:data_sponsor])
+      expect(metadata[:departments]).to eq(project.metadata[:departments])
+      # TODO Should really utilize MediafluxTime, but the time class upcases the date and does not zero pad the day
+      expect(metadata[:created_on]).to eq(Time.zone.parse(created_on).strftime("%d-%b-%Y %H:%M:%S"))
+      expect(metadata[:created_by]).to eq(project.metadata[:created_by])
+      expect(metadata[:ro_users]).to eq([data_user_ro.uid])
+      expect(metadata[:rw_users]).to eq([data_user_rw.uid])
     end
 
     context "A collection within a collection" do
@@ -84,7 +55,7 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
       end
 
       it "parses a metadata response" do
-        create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", collection: true, pid: "5678")
+        create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", pid: "5678")
         expect(create_request.id).to eq("1068")
         expect(a_request(:post, mediflux_url).with do |req| 
             req.body.include?("<name>testasset</name>") && 
@@ -100,7 +71,7 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
     it "creates the asset create payload" do
       project = FactoryBot.create :project, project_id: "abc-123"
       tigerdata_values = ProjectMediaflux.project_values(project:)
-      create_request = described_class.new(session_token: nil, name: "testasset", collection: false, tigerdata_values: tigerdata_values)
+      create_request = described_class.new(session_token: nil, name: "testasset", tigerdata_values: tigerdata_values)
       expected_xml = "<?xml version=\"1.0\"?>\n" \
       "<request xmlns:tigerdata=\"http://tigerdata.princeton.edu\">\n" \
       "  <service name=\"asset.create\">\n" \
@@ -132,6 +103,8 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
       "          <SchemaVersion>0.6.1</SchemaVersion>\n" \
       "        </tigerdata:project>\n" \
       "      </meta>\n" \
+      "      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n" \
+      "      <type>application/arc-asset-collection</type>\n" \
       "    </args>\n" \
       "  </service>\n" \
       "</request>\n"
@@ -143,7 +116,7 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
     it "creates the asset create xml in a format that can be passed to xtoshell in aterm" do
       project = FactoryBot.create :project, project_id: "abc-123"
       tigerdata_values = ProjectMediaflux.project_values(project:)
-      create_request = described_class.new(session_token: nil, name: "testasset", collection: false, tigerdata_values: tigerdata_values)
+      create_request = described_class.new(session_token: nil, name: "testasset", tigerdata_values: tigerdata_values)
       expected_xml = "<request xmlns:tigerdata='http://tigerdata.princeton.edu'><service name='asset.create'><name>testasset</name>" \
                      "<meta><tigerdata:project><ProjectDirectory>#{project.project_directory}</ProjectDirectory><Title>#{project.metadata[:title]}</Title>" \
                      "<Description>#{project.metadata[:description]}</Description><Status>#{project.metadata[:status]}</Status>" \
@@ -152,7 +125,9 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
                      "<CreatedBy>#{project.metadata[:created_by]}</CreatedBy><ProjectID>abc-123</ProjectID><StorageCapacity><Size>500</Size><Unit>GB</Unit></StorageCapacity>" \
                      "<Performance Requested='standard'>standard</Performance><Submission><RequestedBy>#{project.metadata[:created_by]}</RequestedBy>" \
                      "<RequestDateTime>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</RequestDateTime></Submission>" \
-                     "<ProjectPurpose>research</ProjectPurpose><SchemaVersion>0.6.1</SchemaVersion></tigerdata:project></meta></service></request>"
+                     "<ProjectPurpose>research</ProjectPurpose><SchemaVersion>0.6.1</SchemaVersion></tigerdata:project></meta>" \
+                     "<collection cascade-contained-asset-index='true' contained-asset-index='true' unique-name-index='true'>true</collection>" \
+                     "<type>application/arc-asset-collection</type></service></request>"
       expect(create_request.xtoshell_xml).to eq(expected_xml)
     end
   end

--- a/spec/models/mediaflux/http/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_metadata_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Mediaflux::Http::AssetMetadataRequest, type: :model do
         metadata = metadata_request.metadata
         expect(metadata[:id]).to eq("1065")
         expect(metadata[:creator]).to eq("manager")
-        expect(metadata[:description]).to eq("")
+        expect(metadata[:description]).to eq("Description of project accum 07576")
         expect(metadata[:collection]).to be_truthy
         expect(metadata[:path]).to eq("/td-test-001/collection-96-58278")
         expect(metadata[:type]).to eq("application/arc-asset-collection")
@@ -75,7 +75,7 @@ RSpec.describe Mediaflux::Http::AssetMetadataRequest, type: :model do
         metadata = metadata_request.metadata
         expect(metadata[:id]).to eq(valid_project.mediaflux_id.to_s)
         expect(metadata[:creator]).to eq("manager")
-        expect(metadata[:description]).to eq("")
+        expect(metadata[:description]).to eq("a random description")
         expect(metadata[:collection]).to be_truthy
         expect(metadata[:path].include?(valid_project.metadata_json["project_directory"])).to be_truthy
         expect(metadata[:type]).to eq("application/arc-asset-collection")

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -12,11 +12,16 @@ RSpec.configure do |config|
       Rails.application.load_tasks
       Rake::Task["schema:create"].invoke
       # Clean out the namespace before running tests to avoid collisions
-      user = FactoryBot.create :user
+      user = User.new
       Mediaflux::Http::NamespaceDestroyRequest.new(
         session_token: user.mediaflux_session,
         namespace: Rails.configuration.mediaflux[:api_root_ns]
       ).destroy
+      # then create it so it exists for any tests
+      Mediaflux::Http::NamespaceCreateRequest.new(
+        session_token: user.mediaflux_session,
+        namespace: Rails.configuration.mediaflux[:api_root_ns]
+      ).resolve
     end
   rescue StandardError => namespace_error
     message = "Bypassing pre-test cleanup error, #{namespace_error.message}"


### PR DESCRIPTION
We really are not creating anything but collection assets and likely will not be in the future. No need to keep the additional code options.

Also changed one of the tests to contact mediaflux, which required updates to AssetMetadataRequest to validate all the input.

refs #753 