### PR TITLE
Splitting project creation into a specialized ProjectCreate class

### DIFF
--- a/app/models/mediaflux/http/asset_create_request.rb
+++ b/app/models/mediaflux/http/asset_create_request.rb
@@ -9,13 +9,11 @@ module Mediaflux
       # @param name [String] Name of the Asset
       # @param namespace [String] Optional Parent namespace for the asset to be created in
       # @param pid [String] Optional Parent collection id (use this or a namespace not both)
-      # @param tigerdata_values [Hash] Optional parameter for the tigerdata metdata to be applied to the new asset in the meta field
       # @param xml_namespace [String]
-      def initialize(session_token:, namespace: nil, name:, tigerdata_values: nil, xml_namespace: nil, xml_namespace_uri: nil, pid: nil)
+      def initialize(session_token:, namespace: nil, name:, xml_namespace: nil, xml_namespace_uri: nil, pid: nil)
         super(session_token: session_token)
         @namespace = namespace
         @asset_name = name
-        @tigerdata_values = tigerdata_values
         @xml_namespace = xml_namespace || self.class.default_xml_namespace
         @xml_namespace_uri = xml_namespace_uri || self.class.default_xml_namespace_uri
         @pid = pid
@@ -49,7 +47,7 @@ module Mediaflux
             xml.args do
               xml.name asset_name
               xml.namespace namespace if namespace.present?
-              tigerdata_values_xml(xml)
+              yield xml if block_given?
               collection_xml(xml)
               if @pid.present?
                 xml.pid @pid
@@ -67,62 +65,6 @@ module Mediaflux
           end
           xml.type "application/arc-asset-collection"
         end
-
-        # rubocop:disable Metrics/MethodLength
-        # rubocop:disable Metrics/AbcSize
-        def tigerdata_values_xml(xml)
-          return unless @tigerdata_values
-          xml.meta do
-            doc = xml.doc
-            root = doc.root
-            # Define the namespace only if this is required
-            root.add_namespace_definition(@xml_namespace, @xml_namespace_uri)
-
-            element_name = @xml_namespace.nil? ? "project" : "#{@xml_namespace}:project"
-            xml.send(element_name) do
-              xml.ProjectDirectory @tigerdata_values[:project_directory]
-              xml.Title @tigerdata_values[:title]
-              xml.Description @tigerdata_values[:description] if @tigerdata_values[:description].present?
-              xml.Status @tigerdata_values[:status]
-              xml.DataSponsor @tigerdata_values[:data_sponsor]
-              xml.DataManager @tigerdata_values[:data_manager]
-              departments = @tigerdata_values[:departments] || []
-              departments.each do |department|
-                xml.Department department
-              end
-              ro_users = @tigerdata_values[:data_user_read_only] || []
-              ro_users.each do |ro_user|
-                xml.DataUser do
-                  xml.parent.set_attribute("ReadOnly", true)
-                  xml.text(ro_user)
-                end
-              end
-              rw_users = @tigerdata_values[:data_user_read_write] || []
-              rw_users.each do |rw_user|
-                xml.DataUser rw_user
-              end
-              xml.CreatedOn @tigerdata_values[:created_on]
-              xml.CreatedBy @tigerdata_values[:created_by]
-              xml.ProjectID @tigerdata_values[:project_id]
-              xml.StorageCapacity do
-                xml.Size @tigerdata_values[:storage_capacity][:size][:requested]
-                xml.Unit @tigerdata_values[:storage_capacity][:unit][:requested]
-              end
-              xml.Performance do
-                xml.parent.set_attribute("Requested", @tigerdata_values[:storage_performance][:requested])
-                xml.text(@tigerdata_values[:storage_performance][:requested])
-              end
-              xml.Submission do
-                xml.RequestedBy @tigerdata_values[:created_by]
-                xml.RequestDateTime @tigerdata_values[:created_on]
-              end
-              xml.ProjectPurpose @tigerdata_values[:project_purpose]
-              xml.SchemaVersion TigerdataSchema::SCHEMA_VERSION
-            end
-          end
-        end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/models/mediaflux/http/project_create_request.rb
+++ b/app/models/mediaflux/http/project_create_request.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class ProjectCreateRequest < AssetCreateRequest
+      attr_reader :namespace, :project, :collection
+
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      # @param namespace [String] Parent namespace for the asset to be created in
+      # @param project [Project] project to be created in Mediaflux
+      # @param pid [String] Optional Parent collection id (use this or a namespace not both)
+      # @param xml_namespace [String] Optional parameter for metadata xml namspace
+      # @param xml_namespace_uri [String] Optional parameter for metadata xml namspace url 
+      def initialize(session_token:, namespace:, project:,  xml_namespace: nil, xml_namespace_uri: nil, pid: nil)
+        super(session_token:, namespace:, name: project.project_directory_short,  xml_namespace:, xml_namespace_uri:,  pid:)
+        @project = project
+      end
+
+      private
+
+        # The generated XML mimics what we get when we issue an Aterm command as follows:
+        # > asset.set :id path=/sandbox_ns/rdss_collection
+        #     :meta <
+        #       :tigerdata:project <
+        #         :title "RDSS test project"
+        #         :description "The description of the project"
+        #         ...the rest of the fields go here..
+        #       >
+        #     >
+        #
+        def build_http_request_body(name:)
+          super do |xml|
+            project_xml(xml)
+          end
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/AbcSize
+        def project_xml(xml)
+          xml.meta do
+            root = xml.doc.root
+            root.add_namespace_definition(@xml_namespace, @xml_namespace_uri)
+      
+            xml.send("#{@xml_namespace}:project") do
+              xml.ProjectDirectory project.project_directory
+              xml.Title project.metadata[:title]
+              xml.Description project.metadata[:description] if project.metadata[:description].present?
+              xml.Status project.metadata[:status]
+              xml.DataSponsor project.metadata[:data_sponsor]
+              xml.DataManager project.metadata[:data_manager]
+              departments =  project.metadata[:departments] || []
+              departments.each do |department|
+                xml.Department department
+              end
+              ro_users = project.metadata[:data_user_read_only] || []
+              ro_users.each do |ro_user|
+                xml.DataUser do
+                  xml.parent.set_attribute("ReadOnly", true)
+                  xml.text(ro_user)
+                end
+              end
+              rw_users = project.metadata[:data_user_read_write] || []
+              rw_users.each do |rw_user|
+                xml.DataUser rw_user
+              end
+              created_on = MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])
+              xml.CreatedOn created_on
+              xml.CreatedBy project.metadata[:created_by]
+              xml.ProjectID project.metadata[:project_id]
+              capacity = project.metadata[:storage_capacity]
+              xml.StorageCapacity do
+                xml.Size capacity["size"]["requested"]
+                xml.Unit capacity["unit"]["requested"]
+              end
+              performance = project.metadata[:storage_performance_expectations]
+              xml.Performance do
+                xml.parent.set_attribute("Requested", performance["requested"])
+                xml.text(performance["requested"])
+              end
+              xml.Submission do
+                xml.RequestedBy project.metadata[:created_by]
+                xml.RequestDateTime created_on
+              end
+              xml.ProjectPurpose project.metadata[:project_purpose]
+              xml.SchemaVersion TigerdataSchema::SCHEMA_VERSION
+            end
+          end
+        end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -30,8 +30,7 @@ class ProjectMediaflux
     tigerdata_values = project_values(project: project)
     project_parent = Rails.configuration.mediaflux["api_root_collection"]
     prepare_parent_collection(project_parent:, session_id:)
-    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: session_id, namespace: project_namespace, name: project.project_directory_short, tigerdata_values: tigerdata_values,
-                                                             xml_namespace: xml_namespace, pid: project_parent)
+    create_request = Mediaflux::Http::ProjectCreateRequest.new(session_token: session_id, namespace: project_namespace, project:, xml_namespace: xml_namespace, pid: project_parent)
     id = create_request.id
     if id.blank?
       response_error = create_request.response_error
@@ -125,9 +124,7 @@ class ProjectMediaflux
     project_namespace = "#{project_name}NS"
     project_parent = Rails.configuration.mediaflux["api_root_collection"]
 
-    tigerdata_values = project_values(project: project)
-    create_request = Mediaflux::Http::AssetCreateRequest.new(session_token: nil, namespace: project_namespace, name: project.project_directory_short, tigerdata_values: tigerdata_values,
-                                                             xml_namespace: xml_namespace, pid: project_parent)
+    create_request = Mediaflux::Http::ProjectCreateRequest.new(session_token: nil, namespace: project_namespace, project:, xml_namespace: xml_namespace, pid: project_parent)
     create_request.xml_payload
   end
 

--- a/spec/models/mediaflux/http/asset_create_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_create_request_spec.rb
@@ -10,38 +10,15 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
   end
 
   describe "#id" do
-    before do
-      stub_request(:post, mediflux_url)
-        .with(body: "<?xml version=\"1.0\"?>\n<request>\n  <service name=\"asset.create\" session=\"secretsecret/2/31\">\n    "\
-                    "<args>\n      <name>testasset</name>\n    </args>\n  </service>\n</request>\n")
-        .to_return(status: 200, body: create_response, headers: {})
-    end
+    it "creates a collection on the server", connect_to_mediaflux: true do
+      session_id = User.new.mediaflux_session
 
-    it "sends the metadata to the server", connect_to_mediaflux: true do
-      data_user_ro = FactoryBot.create :user
-      data_user_rw = FactoryBot.create :user
-      session_id =  data_user_ro.mediaflux_session
-
-      created_on = Time.current.in_time_zone("America/New_York").iso8601
-      project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on, project_id: "abc/123"
-      tigerdata_values = ProjectMediaflux.project_values(project:)
-      create_request = described_class.new(session_token: session_id, name: "testasset", tigerdata_values: tigerdata_values, namespace: Rails.configuration.mediaflux[:api_root_ns])
+      create_request = described_class.new(session_token: session_id, name: "testasset", namespace: Rails.configuration.mediaflux[:api_root_ns])
       expect(create_request.response_error).to be_blank
       expect(create_request.id).not_to be_blank
       req = Mediaflux::Http::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
-      metadata  = req.metadata
-      
-      puts "created on #{project.metadata[:created_on]}"
+      metadata = req.metadata
       expect(metadata[:name]).to eq("testasset")
-      expect(metadata[:title]).to eq(project.metadata[:title])
-      expect(metadata[:description]).to eq(project.metadata[:description])
-      expect(metadata[:data_sponsor]).to eq(project.metadata[:data_sponsor])
-      expect(metadata[:departments]).to eq(project.metadata[:departments])
-      # TODO Should really utilize MediafluxTime, but the time class upcases the date and does not zero pad the day
-      expect(metadata[:created_on]).to eq(Time.zone.parse(created_on).strftime("%d-%b-%Y %H:%M:%S"))
-      expect(metadata[:created_by]).to eq(project.metadata[:created_by])
-      expect(metadata[:ro_users]).to eq([data_user_ro.uid])
-      expect(metadata[:rw_users]).to eq([data_user_rw.uid])
     end
 
     context "A collection within a collection" do
@@ -57,52 +34,22 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
       it "parses a metadata response" do
         create_request = described_class.new(session_token: "secretsecret/2/31", name: "testasset", pid: "5678")
         expect(create_request.id).to eq("1068")
-        expect(a_request(:post, mediflux_url).with do |req| 
-            req.body.include?("<name>testasset</name>") && 
-            req.body.include?("<type>application/arc-asset-collection</type>")
-          end
-        ).to have_been_made
+        expect(a_request(:post, mediflux_url).with do |req|
+                 req.body.include?("<name>testasset</name>") &&
+                 req.body.include?("<type>application/arc-asset-collection</type>")
+               end).to have_been_made
       end
     end
-
   end
 
   describe "#xml_payload" do
     it "creates the asset create payload" do
-      project = FactoryBot.create :project, project_id: "abc-123"
-      tigerdata_values = ProjectMediaflux.project_values(project:)
-      create_request = described_class.new(session_token: nil, name: "testasset", tigerdata_values: tigerdata_values)
+      create_request = described_class.new(session_token: nil, name: "testasset")
       expected_xml = "<?xml version=\"1.0\"?>\n" \
-      "<request xmlns:tigerdata=\"http://tigerdata.princeton.edu\">\n" \
+      "<request>\n" \
       "  <service name=\"asset.create\">\n" \
       "    <args>\n" \
       "      <name>testasset</name>\n" \
-      "      <meta>\n" \
-      "        <tigerdata:project>\n" \
-      "          <ProjectDirectory>#{project.project_directory}</ProjectDirectory>\n" \
-      "          <Title>#{project.metadata[:title]}</Title>\n" \
-      "          <Description>#{project.metadata[:description]}</Description>\n" \
-      "          <Status>#{project.metadata[:status]}</Status>\n" \
-      "          <DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor>\n" \
-      "          <DataManager>#{project.metadata[:data_manager]}</DataManager>\n" \
-      "          <Department>RDSS</Department>\n" \
-      "          <Department>PRDS</Department>\n" \
-      "          <CreatedOn>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</CreatedOn>\n" \
-      "          <CreatedBy>#{project.metadata[:created_by]}</CreatedBy>\n" \
-      "          <ProjectID>abc-123</ProjectID>\n" \
-      "          <StorageCapacity>\n" \
-      "            <Size>500</Size>\n" \
-      "            <Unit>GB</Unit>\n" \
-      "          </StorageCapacity>\n" \
-      "          <Performance Requested=\"standard\">standard</Performance>\n" \
-      "          <Submission>\n" \
-      "            <RequestedBy>#{project.metadata[:created_by]}</RequestedBy>\n" \
-      "            <RequestDateTime>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</RequestDateTime>\n" \
-      "          </Submission>\n" \
-      "          <ProjectPurpose>research</ProjectPurpose>\n" \
-      "          <SchemaVersion>0.6.1</SchemaVersion>\n" \
-      "        </tigerdata:project>\n" \
-      "      </meta>\n" \
       "      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n" \
       "      <type>application/arc-asset-collection</type>\n" \
       "    </args>\n" \
@@ -114,18 +61,8 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
 
   describe "#xtoshell_xml" do
     it "creates the asset create xml in a format that can be passed to xtoshell in aterm" do
-      project = FactoryBot.create :project, project_id: "abc-123"
-      tigerdata_values = ProjectMediaflux.project_values(project:)
-      create_request = described_class.new(session_token: nil, name: "testasset", tigerdata_values: tigerdata_values)
-      expected_xml = "<request xmlns:tigerdata='http://tigerdata.princeton.edu'><service name='asset.create'><name>testasset</name>" \
-                     "<meta><tigerdata:project><ProjectDirectory>#{project.project_directory}</ProjectDirectory><Title>#{project.metadata[:title]}</Title>" \
-                     "<Description>#{project.metadata[:description]}</Description><Status>#{project.metadata[:status]}</Status>" \
-                     "<DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor><DataManager>#{project.metadata[:data_manager]}</DataManager>" \
-                     "<Department>RDSS</Department><Department>PRDS</Department><CreatedOn>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</CreatedOn>" \
-                     "<CreatedBy>#{project.metadata[:created_by]}</CreatedBy><ProjectID>abc-123</ProjectID><StorageCapacity><Size>500</Size><Unit>GB</Unit></StorageCapacity>" \
-                     "<Performance Requested='standard'>standard</Performance><Submission><RequestedBy>#{project.metadata[:created_by]}</RequestedBy>" \
-                     "<RequestDateTime>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</RequestDateTime></Submission>" \
-                     "<ProjectPurpose>research</ProjectPurpose><SchemaVersion>0.6.1</SchemaVersion></tigerdata:project></meta>" \
+      create_request = described_class.new(session_token: nil, name: "testasset")
+      expected_xml = "<request><service name='asset.create'><name>testasset</name>" \
                      "<collection cascade-contained-asset-index='true' contained-asset-index='true' unique-name-index='true'>true</collection>" \
                      "<type>application/arc-asset-collection</type></service></request>"
       expect(create_request.xtoshell_xml).to eq(expected_xml)

--- a/spec/models/mediaflux/http/project_create_request_spec.rb
+++ b/spec/models/mediaflux/http/project_create_request_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::Http::ProjectCreateRequest, type: :model do
+  let(:mediflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+
+  let(:create_response) do
+    filename = Rails.root.join("spec", "fixtures", "files", "asset_create_response.xml")
+    File.new(filename).read
+  end
+
+  describe "#id" do
+
+    it "sends the metadata to the server", connect_to_mediaflux: true do
+      data_user_ro = FactoryBot.create :user
+      data_user_rw = FactoryBot.create :user
+      session_id =  data_user_ro.mediaflux_session
+
+      created_on = Time.current.in_time_zone("America/New_York").iso8601
+      project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on, 
+                                            project_id: "abc/123", project_directory: "testasset"
+      create_request = described_class.new(session_token: session_id, project:, namespace: Rails.configuration.mediaflux[:api_root_ns])
+      expect(create_request.response_error).to be_blank
+      expect(create_request.id).not_to be_blank
+      req = Mediaflux::Http::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
+      metadata  = req.metadata
+      
+      puts "created on #{project.metadata[:created_on]}"
+      expect(metadata[:name]).to eq("testasset")
+      expect(metadata[:title]).to eq(project.metadata[:title])
+      expect(metadata[:description]).to eq(project.metadata[:description])
+      expect(metadata[:data_sponsor]).to eq(project.metadata[:data_sponsor])
+      expect(metadata[:departments]).to eq(project.metadata[:departments])
+      # TODO Should really utilize MediafluxTime, but the time class upcases the date and does not zero pad the day
+      expect(metadata[:created_on]).to eq(Time.zone.parse(created_on).strftime("%d-%b-%Y %H:%M:%S"))
+      expect(metadata[:created_by]).to eq(project.metadata[:created_by])
+      expect(metadata[:ro_users]).to eq([data_user_ro.uid])
+      expect(metadata[:rw_users]).to eq([data_user_rw.uid])
+    end
+  end
+
+  describe "#xml_payload" do
+    it "creates the asset create payload" do
+      project = FactoryBot.create :project, project_id: "abc-123", project_directory: "testasset"
+      create_request = described_class.new(session_token: nil, project: project, namespace: nil)
+      expected_xml = "<?xml version=\"1.0\"?>\n" \
+      "<request xmlns:tigerdata=\"http://tigerdata.princeton.edu\">\n" \
+      "  <service name=\"asset.create\">\n" \
+      "    <args>\n" \
+      "      <name>testasset</name>\n" \
+      "      <meta>\n" \
+      "        <tigerdata:project>\n" \
+      "          <ProjectDirectory>#{project.project_directory}</ProjectDirectory>\n" \
+      "          <Title>#{project.metadata[:title]}</Title>\n" \
+      "          <Description>#{project.metadata[:description]}</Description>\n" \
+      "          <Status>#{project.metadata[:status]}</Status>\n" \
+      "          <DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor>\n" \
+      "          <DataManager>#{project.metadata[:data_manager]}</DataManager>\n" \
+      "          <Department>RDSS</Department>\n" \
+      "          <Department>PRDS</Department>\n" \
+      "          <CreatedOn>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</CreatedOn>\n" \
+      "          <CreatedBy>#{project.metadata[:created_by]}</CreatedBy>\n" \
+      "          <ProjectID>abc-123</ProjectID>\n" \
+      "          <StorageCapacity>\n" \
+      "            <Size>500</Size>\n" \
+      "            <Unit>GB</Unit>\n" \
+      "          </StorageCapacity>\n" \
+      "          <Performance Requested=\"standard\">standard</Performance>\n" \
+      "          <Submission>\n" \
+      "            <RequestedBy>#{project.metadata[:created_by]}</RequestedBy>\n" \
+      "            <RequestDateTime>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</RequestDateTime>\n" \
+      "          </Submission>\n" \
+      "          <ProjectPurpose>research</ProjectPurpose>\n" \
+      "          <SchemaVersion>0.6.1</SchemaVersion>\n" \
+      "        </tigerdata:project>\n" \
+      "      </meta>\n" \
+      "      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n" \
+      "      <type>application/arc-asset-collection</type>\n" \
+      "    </args>\n" \
+      "  </service>\n" \
+      "</request>\n"
+      expect(create_request.xml_payload).to eq(expected_xml)
+    end
+  end
+
+  describe "#xtoshell_xml" do
+    it "creates the asset create xml in a format that can be passed to xtoshell in aterm" do
+      project = FactoryBot.create :project, project_id: "abc-123", project_directory: "testasset"
+      create_request = described_class.new(session_token: nil, project: project, namespace: nil)
+      expected_xml = "<request xmlns:tigerdata='http://tigerdata.princeton.edu'><service name='asset.create'><name>testasset</name>" \
+                     "<meta><tigerdata:project><ProjectDirectory>#{project.project_directory}</ProjectDirectory><Title>#{project.metadata[:title]}</Title>" \
+                     "<Description>#{project.metadata[:description]}</Description><Status>#{project.metadata[:status]}</Status>" \
+                     "<DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor><DataManager>#{project.metadata[:data_manager]}</DataManager>" \
+                     "<Department>RDSS</Department><Department>PRDS</Department><CreatedOn>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</CreatedOn>" \
+                     "<CreatedBy>#{project.metadata[:created_by]}</CreatedBy><ProjectID>abc-123</ProjectID><StorageCapacity><Size>500</Size><Unit>GB</Unit></StorageCapacity>" \
+                     "<Performance Requested='standard'>standard</Performance><Submission><RequestedBy>#{project.metadata[:created_by]}</RequestedBy>" \
+                     "<RequestDateTime>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:created_on])}</RequestDateTime></Submission>" \
+                     "<ProjectPurpose>research</ProjectPurpose><SchemaVersion>0.6.1</SchemaVersion></tigerdata:project></meta>" \
+                     "<collection cascade-contained-asset-index='true' contained-asset-index='true' unique-name-index='true'>true</collection>" \
+                     "<type>application/arc-asset-collection</type></service></request>"
+      expect(create_request.xtoshell_xml).to eq(expected_xml)
+    end
+  end
+end


### PR DESCRIPTION
Remove project metadata from asset create
Also utilize the project instead of a hash when initializing the project creation class refs #753