### PR TITLE
Implementing an experimental attempt at integrating Mediaflux status indicator using ActionCable

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,4 +16,6 @@
 @import "emulator";
 @import "header";
 @import "footer";
+@import "components/mediaflux_status";
+
 @import "bootstrap";

--- a/app/assets/stylesheets/components/mediaflux_status.scss
+++ b/app/assets/stylesheets/components/mediaflux_status.scss
@@ -1,0 +1,19 @@
+
+.mediaflux {
+  display: inline-block;
+  color: white;
+  margin-left: 2rem;
+  margin-right: 2rem;
+
+  &-status {
+    display: inline-block;
+
+    &.active::before {
+      content: "\1f7e2";
+    }
+
+    &.inactive::before {
+      content: "\1f534";
+    }
+  }
+}

--- a/app/channels/mediaflux_channel.rb
+++ b/app/channels/mediaflux_channel.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+class MediafluxChannel < ApplicationCable::Channel
+  def subscribed
+    update_state
+  end
+
+  def unsubscribed
+    transmit({ state: false })
+  end
+
+  def update_state
+    state = mf_version.present?
+
+    transmit({ state: state })
+  end
+
+  private
+
+    def superuser
+      User.find_by(superuser: true)
+    end
+
+    def session_token
+      superuser.mediaflux_session
+    end
+
+    def version_request
+      Mediaflux::Http::VersionRequest.new(session_token: session_token)
+    end
+
+    def mf_version
+      version_request.version
+    end
+end

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,3 @@
+import { createConsumer } from '@rails/actioncable';
+
+export default createConsumer();

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,4 @@
+// Import all the channels to be used by Action Cable
+//
+
+import './mediaflux_channel';

--- a/app/javascript/channels/mediaflux_channel.js
+++ b/app/javascript/channels/mediaflux_channel.js
@@ -1,0 +1,36 @@
+import consumer from './consumer';
+
+class MediafluxStatusComponent {
+  constructor(element) {
+    this.element = element;
+  }
+
+  setOnline(value) {
+    this.online = value;
+    if (this.online) {
+      this.element.classList.add('active');
+      this.element.classList.remove('inactive');
+    } else {
+      this.element.classList.add('inactive');
+      this.element.classList.remove('active');
+    }
+  }
+}
+
+consumer.subscriptions.create({ channel: 'MediafluxChannel' }, {
+  buildComponent() {
+    const element = document.querySelector('.mediaflux-status');
+    const component = new MediafluxStatusComponent(element);
+    this.component = component;
+  },
+  connected() {
+    this.perform('update_state');
+  },
+  received(data) {
+    if (!this.component) {
+      this.buildComponent();
+    }
+
+    this.component.setOnline(data.state);
+  },
+});

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -15,6 +15,9 @@ import * as bootstrap from 'bootstrap';
 import { setTargetHtml } from './helper';
 import UserDatalist from './user_datalist';
 
+// ActionCable Channels
+import '../channels';
+
 window.bootstrap = bootstrap;
 
 function initDataUsers() {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= action_cable_meta_tag %>
     <%= vite_client_tag %>
     <script src="//code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <%= vite_javascript_tag 'application' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,10 @@
   <a href="/">
   <%= image_tag("TigerData-LOGO-KO_wide2.svg", alt: "TigerData logo", size: "150x100", id: "logo") %>
   </a>
+      <div class="mediaflux">
+        Mediaflux Status
+        <div class="mediaflux-status inactive"></div>
+      </div>
     <div class="body">
     <%= link_to "Home", root_path, class: "navbar-brand"%>
     <% if current_user %>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
+    "@rails/actioncable": "^7.1.3",
     "@rollup/plugin-inject": "^5.0.3",
     "bootstrap": "^5.2.3",
     "browserslist": "^4.21.5",

--- a/spec/channels/mediaflux_channel_spec.rb
+++ b/spec/channels/mediaflux_channel_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe MediafluxChannel, type: :channel do
+  subject(:channel) { described_class.new(*args) }
+
+  let(:connection) { double(ActionCable::Connection) }
+  let(:identifier) { "test-channel" }
+  let(:args) do
+    [
+      connection,
+      identifier
+    ]
+  end
+  let(:superuser) { FactoryBot.create(:superuser) }
+
+  before do
+    superuser
+    allow(connection).to receive(:identifiers).and_return([])
+    allow(channel).to receive(:transmit)
+    allow(channel).to receive(:update_state).and_call_original
+    allow(described_class).to receive(:new).and_return(channel)
+  end
+
+  describe "#subscribed" do
+    before do
+      stub_request(:post, "http://mediaflux.example.com:8888/__mflux_svc__").to_return(status: 200, body: "", headers: {})
+    end
+
+    it "updates the state based upon the Mediaflux version request" do
+      channel.subscribed
+
+      expect(channel).to have_received(:update_state)
+      expect(channel).to have_received(:transmit).with(state: true)
+    end
+  end
+
+  describe "#unsubscribed" do
+    it "updates the state to 'false'" do
+      channel.unsubscribed
+
+      expect(channel).to have_received(:transmit).with(state: false)
+    end
+  end
+
+  describe "#update_state" do
+    context "when the Mediaflux version cannot be retrieved" do
+      let(:version_request) { instance_double(Mediaflux::Http::VersionRequest) }
+      before do
+        stub_request(:post, "http://mediaflux.example.com:8888/__mflux_svc__").to_return(status: 200, body: "", headers: {})
+        allow(version_request).to receive(:version).and_return(nil)
+        allow(Mediaflux::Http::VersionRequest).to receive(:new).and_return(version_request)
+      end
+
+      it "returns a value of 'false'" do
+        channel.update_state
+
+        expect(channel).to have_received(:transmit).with(state: false)
+      end
+    end
+  end
+end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -16,6 +16,27 @@ RSpec.describe "WelcomeController", stub_mediaflux: true do
       visit project_path(project)
       expect(page).to have_content "You need to sign in or sign up before continuing."
     end
+
+    it "binds the Mediaflux status component to the DOM" do
+      visit "/"
+      expect(page).to have_content "Mediaflux Status"
+      expect(page).to have_css ".mediaflux-status.inactive"
+    end
+
+    context "when the Mediaflux API returns a valid server response with a superuser account" do
+      let(:superuser) { FactoryBot.create(:superuser) }
+
+      before do
+        superuser
+        visit "/"
+      end
+
+      it "defaults to the inactive state for the Mediaflux status component" do
+        expect(page).to have_content "Mediaflux Status"
+        sleep(1)
+        expect(page).to have_css ".mediaflux-status.active"
+      end
+    end
   end
 
   context "authenticated user" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,6 +502,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rails/actioncable@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "@rails/actioncable@npm:7.1.3"
+  checksum: 10c0/6019097498387a9c0684df0be380182820a0480173e05a5c5a830cef6cf3e40c9ec75b834af0396b0f57b4e658891c820163e84b9f2bd1ac293c90f5a12ce488
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-inject@npm:^5.0.3":
   version: 5.0.5
   resolution: "@rollup/plugin-inject@npm:5.0.5"
@@ -3998,6 +4005,7 @@ __metadata:
   resolution: "tiger-data-app@workspace:."
   dependencies:
     "@popperjs/core": "npm:^2.11.6"
+    "@rails/actioncable": "npm:^7.1.3"
     "@rollup/plugin-inject": "npm:^5.0.3"
     "@vitest/coverage-c8": "npm:^0.29.1"
     bootstrap: "npm:^5.2.3"


### PR DESCRIPTION
This utilizes `ActionCable` in Rails to provide a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) UI component for providing Mediaflux connectivity status.
![image](https://github.com/pulibrary/tiger-data-app/assets/1443986/a456a2ec-8af6-4fdc-b18c-e6d29c982d58)

Please freely correct any design errors or suboptimal choices (I have no strong opinions on the location or design of the component itself, and shall correct this in response to all feedback).