### PR TITLE
Changing Mediaflux::Http::AssetUpdateRequest test to call out to mediaflux instead of stubbing

### DIFF
--- a/app/models/mediaflux/http/asset_metadata_request.rb
+++ b/app/models/mediaflux/http/asset_metadata_request.rb
@@ -84,8 +84,6 @@ module Mediaflux
         def parse_project(project)
           return {} if project.blank?
           {
-            created_by: project.xpath("./CreatedBy").text,
-            created_on: project.xpath("./CreatedOn").text,
             description: project.xpath("./Description").text,
             data_sponsor: project.xpath("./DataSponsor").text,
             data_manager: project.xpath("./DataManager").text,
@@ -96,6 +94,15 @@ module Mediaflux
             rw_users: project.xpath("./DataUser[not(@ReadOnly)]").map(&:text),
             submission: parse_submission(project),
             title: project.xpath("./Title").text
+          }.merge(parse_project_dates(project))
+        end
+
+        def parse_project_dates(project)
+          {
+            created_by: project.xpath("./CreatedBy").text,
+            created_on: project.xpath("./CreatedOn").text,
+            updated_by: project.xpath("./UpdatedBy").text,
+            updated_on: project.xpath("./UpdatedOn").text
           }
         end
 

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -27,7 +27,6 @@ class ProjectMediaflux
       raise MediafluxDuplicateNamespaceError.new("Can not create the namespace #{namespace.response_error}")
     end
     # Create a collection asset under the root namespace and set its metadata
-    tigerdata_values = project_values(project: project)
     project_parent = Rails.configuration.mediaflux["api_root_collection"]
     prepare_parent_collection(project_parent:, session_id:)
     create_request = Mediaflux::Http::ProjectCreateRequest.new(session_token: session_id, namespace: project_namespace, project:, xml_namespace: xml_namespace, pid: project_parent)

--- a/spec/models/mediaflux/http/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_metadata_request_spec.rb
@@ -84,6 +84,8 @@ RSpec.describe Mediaflux::Http::AssetMetadataRequest, type: :model do
         expect(metadata[:quota_allocation]).to eq("500 GB")
         expect(metadata[:project_id]).to eq("10.34770/tbd")
         expect(metadata[:project_directory]).to eq(valid_project.project_directory)
+        expect(metadata[:created_by]).to eq(valid_project.metadata[:created_by])
+        expect(metadata[:updated_by]).to be_blank # we have not updted the project so no updated by is available
       end
     end
   end

--- a/spec/models/mediaflux/http/asset_update_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_update_request_spec.rb
@@ -40,28 +40,42 @@ RSpec.describe Mediaflux::Http::AssetUpdateRequest, type: :model do
     end
 
     context "an asset with metadata" do
-      before do
-        stub_request(:post, mediaflux_url).to_return(status: 200, body: update_response, headers: {})
-      end
-      it "sends the metadata to the server" do
+      it "sends the metadata to the server", connect_to_mediaflux: true do
         data_user_ro = FactoryBot.create :user
         data_user_rw = FactoryBot.create :user
+        session_id = data_user_ro.mediaflux_session
         updated_on = Time.current.in_time_zone("America/New_York").iso8601
-        project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], updated_on: updated_on
+        created_on = Time.current.in_time_zone("America/New_York").advance(days: -1).iso8601
+        project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on, 
+                                                project_id: "abc/123", project_directory: "testasset"
+        create_request = Mediaflux::Http::ProjectCreateRequest.new(session_token: session_id, project:, namespace: Rails.configuration.mediaflux[:api_root_ns])
+        expect(create_request.response_error).to be_blank
+        expect(create_request.id).not_to be_blank
+
+        project.metadata_json[:title] = "New Title"
+        project.metadata_json[:updated_by] = data_user_rw.uid
+        project.metadata_json[:updated_on] = updated_on
         tigerdata_values = ProjectMediaflux.project_values(project:)
-        update_request = described_class.new(session_token: "secretsecret/2/31", id: "1234", tigerdata_values: tigerdata_values)
+        update_request = described_class.new(session_token: session_id, id: create_request.id, tigerdata_values: tigerdata_values)
         update_request.resolve
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<Title>#{project.metadata[:title]}</Title>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<Description>#{project.metadata[:description]}</Description>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<DataManager>#{project.metadata[:data_manager]}</DataManager>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<Department>#{project.metadata[:departments].first}</Department>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<Department>#{project.metadata[:departments].last}</Department>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<UpdatedOn>#{MediafluxTime.format_date_for_mediaflux(project.metadata[:updated_on])}</UpdatedOn>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<UpdatedBy>#{project.metadata[:updated_by]}</UpdatedBy>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<DataUser ReadOnly=\"true\">#{data_user_ro.uid}</DataUser>") }).to have_been_made
-        expect(a_request(:post, mediaflux_url).with { |req| req.body.include?("<DataUser>#{data_user_rw.uid}</DataUser>") }).to have_been_made
-      end
+        expect(update_request.response_error).to be_blank
+        # binding.pry
+        req = Mediaflux::Http::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
+        metadata  = req.metadata
+        
+        expect(metadata[:name]).to eq("testasset")
+        expect(metadata[:title]).to eq("New Title")
+        expect(metadata[:description]).to eq(project.metadata[:description])
+        expect(metadata[:data_sponsor]).to eq(project.metadata[:data_sponsor])
+        expect(metadata[:departments]).to eq(project.metadata[:departments])
+        # TODO Should really utilize MediafluxTime, but the time class upcases the date and does not zero pad the day
+        expect(metadata[:created_on]).to eq(Time.zone.parse(created_on).strftime("%d-%b-%Y %H:%M:%S"))
+        expect(metadata[:created_by]).to eq(project.metadata[:created_by])
+        expect(metadata[:updated_on]).to eq(Time.zone.parse(updated_on).strftime("%d-%b-%Y %H:%M:%S"))
+        expect(metadata[:updated_by]).to eq(project.metadata[:updated_by])
+        expect(metadata[:ro_users]).to eq([data_user_ro.uid])
+        expect(metadata[:rw_users]).to eq([data_user_rw.uid])
+        end
     end
 
   end

--- a/spec/models/mediaflux/http/project_create_request_spec.rb
+++ b/spec/models/mediaflux/http/project_create_request_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Mediaflux::Http::ProjectCreateRequest, type: :model do
       req = Mediaflux::Http::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
       metadata  = req.metadata
       
-      puts "created on #{project.metadata[:created_on]}"
       expect(metadata[:name]).to eq("testasset")
       expect(metadata[:title]).to eq(project.metadata[:title])
       expect(metadata[:description]).to eq(project.metadata[:description])


### PR DESCRIPTION
Also allow the update information to be retrieved by the Mediaflux::Http::AssetMetadataRequest

refs #753 