### PR TITLE
Display Mediaflux version on the footer 

### DIFF
--- a/app/controllers/mediaflux_info_controller.rb
+++ b/app/controllers/mediaflux_info_controller.rb
@@ -4,5 +4,9 @@ class MediafluxInfoController < ApplicationController
   def index
     version_request = Mediaflux::Http::VersionRequest.new(session_token: current_user.mediaflux_session)
     @mf_version = version_request.version
+    respond_to do |format|
+      format.html
+      format.json { render json: @mf_version }
+    end
   end
 end

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -14,11 +14,13 @@ import * as bootstrap from 'bootstrap';
 
 import { setTargetHtml } from './helper';
 import UserDatalist from './user_datalist';
+import { displayMediafluxVersion } from './mediafluxVersion.js';
 
 // ActionCable Channels
 import '../channels';
 
 window.bootstrap = bootstrap;
+window.displayMediafluxVersion = displayMediafluxVersion;
 
 function initDataUsers() {
   function counterIncrement(counterId) {

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -14,7 +14,7 @@ import * as bootstrap from 'bootstrap';
 
 import { setTargetHtml } from './helper';
 import UserDatalist from './user_datalist';
-import { displayMediafluxVersion } from './mediafluxVersion.js';
+import { displayMediafluxVersion } from './mediafluxVersion';
 
 // ActionCable Channels
 import '../channels';

--- a/app/javascript/entrypoints/mediafluxVersion.js
+++ b/app/javascript/entrypoints/mediafluxVersion.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line import/prefer-default-export
+export function displayMediafluxVersion() {
+  const placeholderInPage = $('#mediaflux_version').length == 1;
+  if (placeholderInPage === true) {
+    $.ajax({
+      type: 'GET',
+      url: '/mediaflux_info.json',
+      success(data) {
+        $('#mediaflux_version').text(`| Mediaflux: ${data.version}`);
+      },
+    });
+  }
+}

--- a/app/javascript/entrypoints/mediafluxVersion.js
+++ b/app/javascript/entrypoints/mediafluxVersion.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
 export function displayMediafluxVersion() {
-  const placeholderInPage = $('#mediaflux_version').length == 1;
+  const placeholderInPage = $('#mediaflux_version').length === 1;
   if (placeholderInPage === true) {
     $.ajax({
       type: 'GET',

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,6 +17,8 @@
           last updated: <%= @version[:version] %>
         </span>
       </text-style>
+      <!-- Placeholder for us to display the version via AJAX (see mediafluxVersion.js)-->
+      <span id="mediaflux_version"></span>
   </div>
       <div class="content">
         <div class= "pul-accessible">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -97,3 +97,10 @@
     </div>
     <% end %>
   </div>
+
+<script type="module">
+  // Make the AJAX call for version information explicitly on this page
+  // (and for now only on this page) so that we don't make extra calls
+  // to Mediaflux for every page loaded.
+  displayMediafluxVersion();
+</script>

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -53,7 +53,7 @@ test:
   api_root_collection_namespace: '/td-test-001'
   api_root_collection: 'path=/td-test-001/tigerdata'
   api_transport: 'http'
-  api_host: '0.0.0.0'
+  api_host: 'mediaflux.example.com'
   api_port: '8888'
   api_domain: 'system'
   api_user: 'manager'

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -53,7 +53,7 @@ test:
   api_root_collection_namespace: '/td-test-001'
   api_root_collection: 'path=/td-test-001/tigerdata'
   api_transport: 'http'
-  api_host: 'mediaflux.example.com'
+  api_host: '0.0.0.0'
   api_port: '8888'
   api_domain: 'system'
   api_user: 'manager'

--- a/spec/system/emulator_spec.rb
+++ b/spec/system/emulator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Website banner", type: :system, js: true do
+describe "Website banner", type: :system, stub_mediaflux: true, js: true do
   let(:current_user) { FactoryBot.create(:trainer, uid: "pul123") }
   it "has the banner on the homepage" do
     sign_in current_user

--- a/spec/system/project_roles_spec.rb
+++ b/spec/system/project_roles_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Project Edit Page Roles Validation", type: :system do
+RSpec.describe "Project Edit Page Roles Validation", type: :system, stub_mediaflux: true, js: true do
   let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123") }
   let(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987") }
   let(:system_admin) { FactoryBot.create(:sysadmin, uid: "pul777") }

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "WelcomeController", stub_mediaflux: true do
+RSpec.describe "WelcomeController", stub_mediaflux: true, js: true do
   context "unauthenticated user" do
     it "shows the 'Log In' button" do
       visit "/"
@@ -59,6 +59,14 @@ RSpec.describe "WelcomeController", stub_mediaflux: true do
         expect(page).not_to have_content "Please log in"
         expect(page).to have_content "Log Out"
       end
+
+      it "shows the Mediflux version on the home page for a logged in user" do
+        sign_in current_user
+        visit "/"
+        sleep(1)
+        expect(page).to have_content "Mediaflux: 4.16.032"
+      end
+
       it "shows the user projects regardless of the user's role" do
         sign_in current_user
         visit "/"

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "WelcomeController", stub_mediaflux: true, js: true do
         expect(page).to have_content "Log Out"
       end
 
-      it "shows the Mediflux version on the home page for a logged in user" do
+      it "shows the Mediflux version on the home page for a logged in user", connect_to_mediaflux: true do
         sign_in current_user
         visit "/"
         sleep(1)


### PR DESCRIPTION
Display Mediaflux version on the footer. I am only displaying it on the homepage since getting the Mediaflux version requires an extra call to Mediaflux and we don't want to do that for every single page.

![Screenshot 2024-06-26 at 3 18 02 PM](https://github.com/pulibrary/tiger-data-app/assets/568286/cf5aea06-117a-4c31-b788-f4619ea42c16)

Closes #790 