### PR TITLE
Adding a banner to display the alternate mediaflux status

### DIFF
--- a/app/assets/stylesheets/_alternate_mediaflux.scss
+++ b/app/assets/stylesheets/_alternate_mediaflux.scss
@@ -1,0 +1,25 @@
+#alternate_mediaflux {
+    text-align: center;
+    background-color: rgb(0, 231, 73);
+    padding: 20px 0px 10px 0px;
+    border-bottom: #000000 solid 2px;
+    color: rgb(0, 0, 0);
+    box-shadow: inset 0px 9px 10px 2px rgba(0,0,0,0.5);
+
+    h1 {
+      font-size: 24px;
+      font-weight: bold;
+    }
+    p {
+      font-size: 18px;
+    }
+    a {
+      text-decoration: underline;
+    }
+  }
+  
+  @media all and (max-width: 860px) {
+    #emulator {
+      padding: 10px 3px 5px 3px;
+    }
+  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "settings";
 @import "banner";
 @import "emulator";
+@import "alternate_mediaflux";
 @import "header";
 @import "footer";
 @import "components/mediaflux_status";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
   </head>
 
   <body>
+    <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
     <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/emulator' %>

--- a/app/views/shared/_alternate_mediaflux.html.erb
+++ b/app/views/shared/_alternate_mediaflux.html.erb
@@ -1,0 +1,5 @@
+<% if current_user && (current_user.eligible_sysadmin? || current_user.trainer) && Flipflop.alternate_mediaflux? %>
+  <div id="alternate_mediaflux">
+    <h2>You are connected to the Alternate Mediaflux</h2>
+  </div>
+<% end %>


### PR DESCRIPTION
Displays only for super users, trainers, and sysadmins
![Screenshot 2024-07-02 at 7 54 11 AM](https://github.com/pulibrary/tiger-data-app/assets/1599081/d1261372-a358-4991-ae1f-f6cdef35a9c7)
