### PR TITLE
Create root namespace as part of RootCollectionAsset

### DIFF
--- a/app/models/mediaflux/http/namespace_exist_request.rb
+++ b/app/models/mediaflux/http/namespace_exist_request.rb
@@ -4,9 +4,9 @@ module Mediaflux
     class NamespaceExistRequest < Request
       # Constructor
       # @param session_token [String] the API token for the authenticated session
-      def initialize(session_token:, path:)
+      def initialize(session_token:, namespace:)
         super(session_token: session_token)
-        @path = path
+        @namespace = namespace
       end
 
       # Specifies the Mediaflux service to use
@@ -15,7 +15,7 @@ module Mediaflux
         "asset.namespace.exists"
       end
 
-      # Be aware that asset.exists does not return the ID of the asset validated
+      # Be aware that asset.namespace.exists does not return the ID of the asset validated
       # so we cannot return it back to the user (Mediaflux returns the path that
       # we validated but not the actual asset ID. Hence we return true/false for
       # this kind of request.
@@ -28,7 +28,7 @@ module Mediaflux
         def build_http_request_body(name:)
           super do |xml|
             xml.args do
-              xml.id "path=#{@path}"
+              xml.namespace @namespace
             end
           end
         end

--- a/app/models/mediaflux/http/namespace_exist_request.rb
+++ b/app/models/mediaflux/http/namespace_exist_request.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Mediaflux
+  module Http
+    class NamespaceExistRequest < Request
+      # Constructor
+      # @param session_token [String] the API token for the authenticated session
+      def initialize(session_token:, path:)
+        super(session_token: session_token)
+        @path = path
+      end
+
+      # Specifies the Mediaflux service to use
+      # @return [String]
+      def self.service
+        "asset.namespace.exists"
+      end
+
+      # Be aware that asset.exists does not return the ID of the asset validated
+      # so we cannot return it back to the user (Mediaflux returns the path that
+      # we validated but not the actual asset ID. Hence we return true/false for
+      # this kind of request.
+      def exist?
+        response_xml.xpath("/response/reply/result/exists").text == "true"
+      end
+
+      private
+
+        def build_http_request_body(name:)
+          super do |xml|
+            xml.args do
+              xml.id "path=#{@path}"
+            end
+          end
+        end
+    end
+  end
+end

--- a/app/models/mediaflux/root_collection_asset.rb
+++ b/app/models/mediaflux/root_collection_asset.rb
@@ -5,12 +5,14 @@ module Mediaflux
 
     def initialize(session_token:, namespace:, name:)
       @session_token = session_token
-      @namespace = namespace || Rails.configuration.mediaflux["api_root_collection_namespace"]   # /td-prod-001
+      @namespace = namespace || Rails.configuration.mediaflux["api_root_collection_namespace"]   # /princeton or /td-demo-001
       @name = name || Rails.configuration.mediaflux["api_root_collection_name"]                  # tigerdata
       @path = Pathname.new(namespace).join(name).to_s
       @error = nil
     end
 
+    # Creates the root collection asset (e.g. `tigerdata`)
+    # Notice that this collection asset lives under a root namespace (e.g. `/princeton` in production or `td-demo-001` in development)
     def create
       check_root = Mediaflux::Http::AssetExistRequest.new(session_token: @session_token, path: @path)
       return true if check_root.exist?
@@ -28,17 +30,13 @@ module Mediaflux
     private
 
       def create_root_namespace
-        check_root_namespace = Mediaflux::Http::NamespaceExistRequest.new(session_token: @session_token, path: @namespace)
+        check_root_namespace = Mediaflux::Http::NamespaceExistRequest.new(session_token: @session_token, namespace: @namespace)
         return true if check_root_namespace.exist?
 
         create_namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(session_token: @session_token, namespace: @namespace)
         create_namespace_request.resolve
         @error = create_namespace_request.response_error
-        if @error.present?
-          false
-        else
-          true
-        end
+        @error.blank?
       end
   end
 end

--- a/app/models/mediaflux/root_collection_asset.rb
+++ b/app/models/mediaflux/root_collection_asset.rb
@@ -15,10 +15,30 @@ module Mediaflux
       check_root = Mediaflux::Http::AssetExistRequest.new(session_token: @session_token, path: @path)
       return true if check_root.exist?
 
-      create_request = Mediaflux::Http::CollectionAssetCreateRootRequest.new(session_token: @session_token, namespace: @namespace, name: @name)
-      create_request.resolve
-      @error = create_request.response_error
-      create_request.id.present?
+      if create_root_namespace
+        create_request = Mediaflux::Http::CollectionAssetCreateRootRequest.new(session_token: @session_token, namespace: @namespace, name: @name)
+        create_request.resolve
+        @error = create_request.response_error
+        create_request.id.present?
+      else
+        false
+      end
     end
+
+    private
+
+      def create_root_namespace
+        check_root_namespace = Mediaflux::Http::NamespaceExistRequest.new(session_token: @session_token, path: @namespace)
+        return true if check_root_namespace.exist?
+
+        create_namespace_request = Mediaflux::Http::NamespaceCreateRequest.new(session_token: @session_token, namespace: @namespace)
+        create_namespace_request.resolve
+        @error = create_namespace_request.response_error
+        if @error.present?
+          false
+        else
+          true
+        end
+      end
   end
 end

--- a/spec/models/mediaflux/http/namespace_exist_request_spec.rb
+++ b/spec/models/mediaflux/http/namespace_exist_request_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::Http::NamespaceExistRequest, type: :model, connect_to_mediaflux: true do
+  let(:session_token) { Mediaflux::Http::LogonRequest.new.session_token }
+  let(:namespace_root) { FFaker::InternetSE.company_name_single_word }
+
+  describe "#exist" do
+    it "detects whether a namespace exists or not" do
+      subject = described_class.new(session_token: session_token, namespace: namespace_root)
+      expect(subject.exist?).to be false
+
+      # create the namespace
+      Mediaflux::Http::NamespaceCreateRequest.new(session_token: session_token, namespace: namespace_root).resolve
+
+      subject = described_class.new(session_token: session_token, namespace: namespace_root)
+      expect(subject.exist?).to be true
+    end
+  end
+end

--- a/spec/models/mediaflux/root_collection_asset_spec.rb
+++ b/spec/models/mediaflux/root_collection_asset_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::RootCollectionAsset, type: :model, connect_to_mediaflux: true do
   let(:session_token) { Mediaflux::Http::LogonRequest.new.session_token }
-  let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
+  let(:namespace_root) { FFaker::InternetSE.company_name_single_word }
   let(:name) { FFaker::InternetSE.company_name_single_word }
 
   describe "#create" do
@@ -16,10 +16,12 @@ RSpec.describe Mediaflux::RootCollectionAsset, type: :model, connect_to_mediaflu
       expect(subject.create).to be true
     end
 
-    it "handles errors when the namespace root is not valid" do
-      subject = described_class.new(session_token: session_token, namespace: namespace_root + "invalid", name: name)
+    it "detects when an invalid namespace or name is used" do
+      subject = described_class.new(session_token: session_token, namespace: "", name: name)
       expect(subject.create).to be false
-      expect(subject.error).not_to be_empty
+
+      subject = described_class.new(session_token: session_token, namespace: namespace_root, name: "")
+      expect(subject.create).to be false
     end
   end
 end


### PR DESCRIPTION
Updated the `RootCollectionAsset` class to take care of the root namespace as well. Added a new class to check whether a namespace exists too.

(code to create the root has not yet been integrated into the existing code, but the functionality to create the root collection and its associated namespace is now complete and will be integrated in the next PR)

Part of #791 