### PR TITLE
Fixes flaky test

### DIFF
--- a/spec/models/mediaflux/http/asset_create_request_spec.rb
+++ b/spec/models/mediaflux/http/asset_create_request_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
   let(:mediflux_url) { "http://mediaflux.example.com:8888/__mflux_svc__" }
+  let(:session_token) { Mediaflux::Http::LogonRequest.new.session_token }
+  let(:root_ns) { Rails.configuration.mediaflux["api_root_collection_namespace"] }        # /td-test-001
+  let(:parent_collection) { Rails.configuration.mediaflux["api_root_collection_name"] }   # tigerdata
 
   let(:create_response) do
     filename = Rails.root.join("spec", "fixtures", "files", "asset_create_response.xml")
@@ -11,6 +14,7 @@ RSpec.describe Mediaflux::Http::AssetCreateRequest, type: :model do
 
   describe "#id" do
     it "creates a collection on the server", connect_to_mediaflux: true do
+      Mediaflux::RootCollectionAsset.new(session_token: session_token, root_ns: root_ns, parent_collection: parent_collection).create
       session_id = User.new.mediaflux_session
 
       create_request = described_class.new(session_token: session_id, name: "testasset", namespace: Rails.configuration.mediaflux[:api_root_ns])

--- a/spec/models/mediaflux/root_collection_asset_spec.rb
+++ b/spec/models/mediaflux/root_collection_asset_spec.rb
@@ -3,24 +3,24 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::RootCollectionAsset, type: :model, connect_to_mediaflux: true do
   let(:session_token) { Mediaflux::Http::LogonRequest.new.session_token }
-  let(:namespace_root) { FFaker::InternetSE.company_name_single_word }
-  let(:name) { FFaker::InternetSE.company_name_single_word }
+  let(:root_ns) { FFaker::InternetSE.company_name_single_word }
+  let(:parent_collection) { FFaker::InternetSE.company_name_single_word }
 
   describe "#create" do
     it "creates the root collection asset" do
-      subject = described_class.new(session_token: session_token, namespace: namespace_root, name: name)
+      subject = described_class.new(session_token: session_token, root_ns: root_ns, parent_collection: parent_collection)
       expect(subject.create).to be true
 
       # make a second call to check that it is idempotent
-      subject = described_class.new(session_token: session_token, namespace: namespace_root, name: name)
+      subject = described_class.new(session_token: session_token, root_ns: root_ns, parent_collection: parent_collection)
       expect(subject.create).to be true
     end
 
     it "detects when an invalid namespace or name is used" do
-      subject = described_class.new(session_token: session_token, namespace: "", name: name)
+      subject = described_class.new(session_token: session_token, root_ns: "", parent_collection: parent_collection)
       expect(subject.create).to be false
 
-      subject = described_class.new(session_token: session_token, namespace: namespace_root, name: "")
+      subject = described_class.new(session_token: session_token, root_ns: root_ns, parent_collection: "")
       expect(subject.create).to be false
     end
   end


### PR DESCRIPTION
Added code to create the tigerdataNS namespace under the the root namespace
    
Update test to call the code to make sure the `root_ns` (e.g. `/princeton` or `/td-demo-001`), `parent_collection` (`tigerdata`), and `parent_ns` (`tigerdataNS`) are created.

Co-authored-by: Jaymee Hyppolite <jaymeeh@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>
Co-authored-by: James R. Griffin III <jrgriffiniii@users.noreply.github.com>
