### PR TITLE
Do not allow infinite retries on the mediaflux session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,9 +20,15 @@ class ApplicationController < ActionController::Base
       # current_user&.mediaflux_from_session(session)
       yield
     rescue Mediaflux::Http::SessionExpired
+      @retry_count ||= 0
+      @retry_count += 1
       current_user.clear_mediaflux_session(session)
       current_user.mediaflux_from_session(session)
-      retry
+      if @retry_count < 3 # If the session is expired we should not have to retry more than once, but let's have a little wiggle room
+        retry
+      else
+        raise
+      end
     end
 
     def emulate_user

--- a/spec/controllers/mediaflux_info_controller_spec.rb
+++ b/spec/controllers/mediaflux_info_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe MediafluxInfoController do
+  let(:user) { FactoryBot.create :user }
+  before do
+    sign_in user
+  end
+
+  it "gets the mediaflux information", connect_to_mediaflux: true do
+    expect { get :index, format: "json" }.not_to raise_error(Mediaflux::Http::SessionExpired)
+    expect(response.body).to eq("{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.032\"}")
+  end
+
+  it "does not retry infinately", connect_to_mediaflux: true do
+    original_pass = Rails.configuration.mediaflux["api_password"]
+    original_session = user.mediaflux_session
+
+    # logout the session so we get an error and need to reset the session
+    Mediaflux::Http::LogoutRequest.new(session_token: original_session).resolve
+
+    Rails.configuration.mediaflux["api_password"] = "badpass"
+
+    expect { get :index }.to raise_error(Mediaflux::Http::SessionExpired)
+
+    Rails.configuration.mediaflux["api_password"] = original_pass
+  end
+end


### PR DESCRIPTION
fixes #802 