### PR TITLE
Ensuring that the user account lm4677 is provided with admin privileges for contributions as a core developer

### DIFF
--- a/data/user_registration_list_development.csv
+++ b/data/user_registration_list_development.csv
@@ -8,6 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
+lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/data/user_registration_list_production.csv
+++ b/data/user_registration_list_production.csv
@@ -8,6 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
+lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/data/user_registration_list_qa.csv
+++ b/data/user_registration_list_qa.csv
@@ -8,6 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
+lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/data/user_registration_list_staging.csv
+++ b/data/user_registration_list_staging.csv
@@ -8,6 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
+lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/data/user_registration_list_test.csv
+++ b/data/user_registration_list_test.csv
@@ -8,6 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
+lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,26 +87,26 @@ RSpec.describe User, type: :model do
     it "creates a new user for every line in the file" do
       expect(User.count).to eq 0
       User.load_registration_list
-      expect(User.count).to eq 39
+      expect(User.count).to eq 40
     end
     it "does not create a user if they exist already" do
       User.create(uid: "mjc12", family_name: "Chandler", display_name: "Matt Chandler", email: "mjc12@princeton.edu")
       expect(User.count).to eq 1
       User.load_registration_list
-      expect(User.count).to eq 39
+      expect(User.count).to eq 40
       user = User.find_by(uid: "mjc12")
       # If we don't say that this is a cas user, they won't be able to log in with CAS
       expect(user.provider).to eq "cas"
     end
     it "updates a name if the name is updated in the spreadsheet" do
       User.load_registration_list
-      expect(User.count).to eq 39
+      expect(User.count).to eq 40
       blank_name_user = User.find_by(uid: "munan")
       expect(blank_name_user.family_name).to be_nil
       expect(blank_name_user.display_name).to be_nil
       allow(User).to receive(:csv_data).and_return(updated_csv_data)
       User.load_registration_list
-      expect(User.count).to eq 39
+      expect(User.count).to eq 40
       updated_name_user = User.find_by(uid: "munan")
       expect(updated_name_user.family_name).to eq "Nøme"
       expect(updated_name_user.display_name).to eq "Fáké Nøme"


### PR DESCRIPTION
This is going to be necessary in order to ensure that @20LM22 is in the position to interact with the application after invoking the command `bundle exec rake load_users:from_registration_list`