### PR TITLE
Removing Datadog for staging deployments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "net-http-persistent"
 gem "sidekiq"
 
 gem "whenever", require: false
-group :staging, :production do
+group :test, :production do
   gem "ddtrace", require: "ddtrace/auto_instrument"
 end
 

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -8,11 +8,11 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.service = "tigerdata"
   c.version = "1.0.0"
-  c.profiling.enabled = Rails.env.staging? || Rails.env.production?
+  c.profiling.enabled = Rails.env.production?
 
   c.tracing.report_hostname = true
   c.tracing.analytics.enabled = true
-  c.tracing.enabled = Rails.env.staging? || Rails.env.production?
+  c.tracing.enabled = Rails.env.production?
   c.tracing.report_hostname = true
   c.tracing.log_injection = true
 


### PR DESCRIPTION
This was triggering intermittent deployment failures when using Capistrano.