### PR TITLE
I762 20lm22 add language to dash

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -186,7 +186,7 @@ class ProjectsController < ApplicationController
     project_job_service.list_contents_job(user: current_user)
 
     json_response = {
-      message: "File list for \"#{project.title}\" is being generated in the background."
+      message: "File list for \"#{project.title}\" is being generated in the background. A link to the downloadable file list will be available in the \"Recent Activity\" section of your dashboard when it is available. You may safely navigate away from this page or close this tab."
     }
     render json: json_response
   rescue => ex

--- a/data/user_registration_list_development.csv
+++ b/data/user_registration_list_development.csv
@@ -8,7 +8,7 @@ kl37,,Kate,Lynch,Kate Lynch,TRUE,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData 
 hc8719,,Hector,Correa,Hector Correa,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 bs3097,,Bess,Sadler,Bess Sadler,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 cac9,,Carolyn,Cole,Carolyn Cole,,TRUE,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
-lm4677,,Lauren Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
+lm4677,,Lauren,Malek,Lauren Malek,,,TRUE,,,2024-07-08,Matt Chandler,TigerData Staff
 jrg5,,James,Griffin,James Griffin,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 rl3667,,Robert,Lee-Faison,Robert Lee-Faison,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff
 jh6441,,Jaymee,Hyppolite,Jaymee Hyppolite,,,TRUE,,,2023-12-05,Matt Chandler,TigerData Staff

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,11 +21,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_27_164616) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "project_accumulators", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "projects", force: :cascade do |t|
     t.integer "mediaflux_id"
     t.jsonb "metadata_json"


### PR DESCRIPTION
Resolves #762, adding language to the dashboard about file list download. I attempted to view the update locally, but that portion of the site doesn't look like it's currently up, so I haven't been able to verify that the message bar reads with the new language. Also fixes a missing comma from when I was added to the registration list.