### PR TITLE
Try to make the test less flaky

### DIFF
--- a/spec/models/mediaflux/collection_asset_create_root_request_spec.rb
+++ b/spec/models/mediaflux/collection_asset_create_root_request_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Mediaflux::CollectionAssetCreateRootRequest, type: :model, connect_to_mediaflux: true do
   let(:session_token) { Mediaflux::LogonRequest.new.session_token }
   let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
-  let(:name) { FFaker::InternetSE.company_name_single_word }
+  let(:name) { FFaker::InternetSE.company_name_single_word + Random.rand(1000).to_s }
 
   it "creates a collection asset only if it does not exist already" do
     subject = described_class.new(session_token: session_token, namespace: namespace_root, name: name)


### PR DESCRIPTION
The only way I can see this test failing *sometimes* is if `FFaker::InternetSE.company_name_single_word` is giving the same value for another test in the entire RSpec suite during the same run. 

In this PR I am forcing the value generated for this test to be unique. This should prevent the tests on `collection_asset_create_root_request_spec.rb` from being flaky on CI. Fingers crossed.

Moves #828 forward.