### PR TITLE
HTTP custom headers for Mediaflux authentication

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -26,5 +26,21 @@ class WelcomeController < ApplicationController
     end
   end
 
-  def help; end
+  def help
+    # Piggybacking on this page to pass custom HTTP headers to Mediaflux
+    # in a very controlled scenario.
+    root_ns = Rails.configuration.mediaflux["api_root_collection_namespace"]
+    parent_collection = Rails.configuration.mediaflux["api_root_collection_name"]
+    @test_path = Pathname.new(root_ns).join(parent_collection)
+    @test_http_headers = false
+    if current_user != nil
+      @test_http_headers = params["http-headers"] == "true"
+      request = if @test_http_headers
+        Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path, session_user: @test_user)
+      else
+        Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path)
+      end
+      @test_path_exist = request.exist?
+    end
+  end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -33,13 +33,13 @@ class WelcomeController < ApplicationController
     parent_collection = Rails.configuration.mediaflux["api_root_collection_name"]
     @test_path = Pathname.new(root_ns).join(parent_collection)
     @test_http_headers = false
-    if current_user != nil
+    unless current_user.nil?
       @test_http_headers = params["http-headers"] == "true"
       request = if @test_http_headers
-        Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path, session_user: @test_user)
-      else
-        Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path)
-      end
+                  Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path, session_user: current_user)
+                else
+                  Mediaflux::AssetExistRequest.new(session_token: current_user.mediaflux_session, path: @test_path)
+                end
       @test_path_exist = request.exist?
     end
   end

--- a/app/models/mediaflux/asset_exist_request.rb
+++ b/app/models/mediaflux/asset_exist_request.rb
@@ -3,8 +3,8 @@ module Mediaflux
   class AssetExistRequest < Request
     # Constructor
     # @param session_token [String] the API token for the authenticated session
-    def initialize(session_token:, path:)
-      super(session_token: session_token)
+    def initialize(session_token:, path:, session_user: nil)
+      super(session_token: session_token, session_user: session_user)
       @path = path
     end
 

--- a/app/models/mediaflux/request.rb
+++ b/app/models/mediaflux/request.rb
@@ -46,10 +46,11 @@ module Mediaflux
       # @param file [File] any upload file required for the POST request
       # @param session_token [String] the API token for the authenticated session
       # @param http_client [Net::HTTP::Persistent] HTTP client for transmitting requests to the Mediaflux server API
-      def initialize(file: nil, session_token: nil, http_client: nil)
+      def initialize(file: nil, session_token: nil, http_client: nil, session_user: nil)
         @http_client = http_client || self.class.find_or_create_http_client
         @file = file
         @session_token = session_token
+        @session_user = session_user
       end
 
       # Resolves the HTTP request against the Mediaflux API
@@ -134,7 +135,7 @@ module Mediaflux
 
         def build_http_request_body(name:)
           args = { name: name }
-                                                # must use @session_token here instead of session_token 
+                                                # must use @session_token here instead of session_token
                                                 #  for login to not go into an infinaite loop
           args[:session] = session_token unless @session_token.nil?
 
@@ -152,6 +153,8 @@ module Mediaflux
           request = self.class.build_post_request
 
           Rails.logger.debug(xml_payload)
+          set_authentication_headers(request)
+
           if form_file.nil?
             request["Content-Type"] = "text/xml; charset=utf-8"
             request.body = xml_payload(name:)
@@ -167,5 +170,15 @@ module Mediaflux
           request
         end
       # rubocop:enable Metrics/MethodLength
+
+      # Authentication code to push a few custom HTTP headers to Mediaflux
+      # Eventually the `session_user` will need to be an object that provides the timeout value.
+      def set_authentication_headers(request)
+        return if @session_user.nil?
+
+        request["TIGERDATA_NETID"] = @session_user.uid
+        request["TIGERDATA_DOMAIN"] = "princeton.edu"
+        request["TIGERDATA_TIMEOUT"] = "tbd"
+      end
     end
 end

--- a/app/views/welcome/help.html.erb
+++ b/app/views/welcome/help.html.erb
@@ -1,3 +1,11 @@
 <p>TigerData is still under construction, and you are not registered as a tester at this time.</p>
 
 <p>If you have any questions, please contact the team at <%= link_to("tigerdata@princeton.edu", "mailto:tigerdata@princeton.edu") %>.</p>
+
+<% if current_user %>
+  <h3>HTTP headers test</h3>
+  <p>Custom HTTP headers: <%= @test_http_headers %> </p>
+  <p>User: <%= current_user.uid %> </p>
+  <p>Path: <%= @test_path %></p>
+  <p>Exist?: <%= @test_path_exist %></p>
+<% end %>


### PR DESCRIPTION
Updated the `Mediaflux::AssetExistRequest` to allow it to pass custom HTTP headers in the request to Mediaflux to test authentication. 

The main change is in the base `Mediaflux::Request` class but only the `Mediaflux::AssetExistRequest` has been updated to pass the custom HTTP parameters. 

Updated the Help page to use as playground to execute requests with the current logged in user to pass the custom HTTP parameters when the `http-headers` query string parameter is set to true: 

* http://localhost:3000/help?http-headers=true
* http://localhost:3000/help?http-headers=false (default)

Wireshark capture showing the HTTP headers:

![Screenshot 2024-07-18 at 3 28 15 PM](https://github.com/user-attachments/assets/799508e6-78c4-4a0a-9f5b-c64a385ff4f2)

Closes #834 