### PR TITLE
Move test root under a top level namespace so we can clean up after tests easier

### DIFF
--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -102,20 +102,16 @@ class ProjectMediaflux
     end
   end
 
-  class << self
-
-    private
-      def prepare_parent_collection(project_parent:, session_id:)
-        get_parent = Mediaflux::AssetMetadataRequest.new(session_token: session_id, id: project_parent)
-        if get_parent.error?
-          if project_parent.include?("path=")
-            create_parent_request = Mediaflux::AssetCreateRequest.new(session_token: session_id, namespace: Mediaflux::Connection.root_collection_namespace,
-                                                                            name: Mediaflux::Connection.root_collection_name)
-            raise "Can not create parent collection: #{create_parent_request.response_error}" if create_parent_request.error?
-          else
-            raise "Error finding parent collection (#{project_parent}) #{get_parent.response_error}"
-          end
-        end
+  def self.prepare_parent_collection(project_parent:, session_id:)
+    get_parent = Mediaflux::AssetMetadataRequest.new(session_token: session_id, id: project_parent)
+    if get_parent.error?
+      if project_parent.include?("path=")
+        create_parent_request = Mediaflux::AssetCreateRequest.new(session_token: session_id, namespace: Mediaflux::Connection.root_collection_namespace,
+                                                                        name: Mediaflux::Connection.root_collection_name)
+        raise "Can not create parent collection: #{create_parent_request.response_error}" if create_parent_request.error?
+      else
+        raise "Error finding parent collection (#{project_parent}) #{get_parent.response_error}"
       end
+    end
   end
 end

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -89,10 +89,11 @@ development:
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] || 'change_me' %>
   shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || './public/' %>
 test:
-  api_root_ns: '/td-test-001/tigerdataNS'
+  api_root_to_clean: '/td-test-001/test/'
+  api_root_ns: '/td-test-001/test/tigerdataNS'
   api_root_collection_name: 'tigerdata'
-  api_root_collection_namespace: '/td-test-001'
-  api_root_collection: 'path=/td-test-001/tigerdata'
+  api_root_collection_namespace: '/td-test-001/test'
+  api_root_collection: 'path=/td-test-001/test/tigerdata'
   api_transport: 'http'
   api_host: <%= ENV["TEST_MEDIAFLUX_HOST"] || 'mediaflux.example.com' %>
   api_port: <%= ENV["TEST_MEDIAFLUX_PORT"] || '8888' %>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ProjectsController do
         "      </quota>\n" \
         "      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n" \
         "      <type>application/arc-asset-collection</type>\n" \
-        "      <pid>path=/td-test-001/tigerdata</pid>\n" \
+        "      <pid>path=/td-test-001/test/tigerdata</pid>\n" \
         "    </args>\n" \
         "  </service>\n" \
         "</request>\n"

--- a/spec/fixtures/files/asset_create_error_response.xml
+++ b/spec/fixtures/files/asset_create_error_response.xml
@@ -6,14 +6,14 @@
     </server>
     <error>arc.mf.server.Services$ExServiceError</error>
     <sclass>java.lang.Throwable</sclass>
-    <message>call to service 'asset.create' failed: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'
+    <message>call to service 'asset.create' failed: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'
 Context:
-            08-Feb-2024 13:19:05.114 [0.009 sec(s) ago]: service: system:manager [sid=236]: asset.create :name  "big-data" :namespace  "/td-test-001/tigerdataNS/big-dataNS" :meta &lt; :tigerdata:project -xmlns:tigerdata "tigerdata" -id "2" &lt; :code  "******" :title  "******" :description  "******" :status  "******" :data_sponsor  "******" :data_manager  "******" :departments  "******" :departments  "******" :created_on  "******" :created_by  "******" :project_id  "******" :storage_capacity  "******" :storage_performance  "******" :project_purpose  "******" &gt; &gt; :collection -cascade-contained-asset-index "true" -contained-asset-index "true" -unique-name-index "true"  "true" :type  "application/arc-asset-collection" 
+            08-Feb-2024 13:19:05.114 [0.009 sec(s) ago]: service: system:manager [sid=236]: asset.create :name  "big-data" :namespace  "/td-test-001/test/tigerdataNS/big-dataNS" :meta &lt; :tigerdata:project -xmlns:tigerdata "tigerdata" -id "2" &lt; :code  "******" :title  "******" :description  "******" :status  "******" :data_sponsor  "******" :data_manager  "******" :departments  "******" :departments  "******" :created_on  "******" :created_by  "******" :project_id  "******" :storage_capacity  "******" :storage_performance  "******" :project_purpose  "******" &gt; &gt; :collection -cascade-contained-asset-index "true" -contained-asset-index "true" -unique-name-index "true"  "true" :type  "application/arc-asset-collection" 
   called by: 08-Feb-2024 13:19:05.112 [0.012 sec(s) ago]: http: from: /192.168.65.1, request: /__mflux_svc__ vars:  select headers: [User-Agent=Ruby, Connection=keep-alive, Host=0.0.0.0:8888]
   called by: 08-Feb-2024 13:19:05.112 [0.012 sec(s) ago]: network: ctime=08-Feb-2024 13:19:05.112, origin=/192.168.65.1, received=1463 [1.46 KB], sent=0 [0 bytes]</message>
-    <stack>arc.mf.server.Services$ExServiceError: call to service 'asset.create' failed: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'
+    <stack>arc.mf.server.Services$ExServiceError: call to service 'asset.create' failed: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'
 Context:
-            08-Feb-2024 13:19:05.114 [0.009 sec(s) ago]: service: system:manager [sid=236]: asset.create :name  "big-data" :namespace  "/td-test-001/tigerdataNS/big-dataNS" :meta &lt; :tigerdata:project -xmlns:tigerdata "tigerdata" -id "2" &lt; :code  "******" :title  "******" :description  "******" :status  "******" :data_sponsor  "******" :data_manager  "******" :departments  "******" :departments  "******" :created_on  "******" :created_by  "******" :project_id  "******" :storage_capacity  "******" :storage_performance  "******" :project_purpose  "******" &gt; &gt; :collection -cascade-contained-asset-index "true" -contained-asset-index "true" -unique-name-index "true"  "true" :type  "application/arc-asset-collection" 
+            08-Feb-2024 13:19:05.114 [0.009 sec(s) ago]: service: system:manager [sid=236]: asset.create :name  "big-data" :namespace  "/td-test-001/test/tigerdataNS/big-dataNS" :meta &lt; :tigerdata:project -xmlns:tigerdata "tigerdata" -id "2" &lt; :code  "******" :title  "******" :description  "******" :status  "******" :data_sponsor  "******" :data_manager  "******" :departments  "******" :departments  "******" :created_on  "******" :created_by  "******" :project_id  "******" :storage_capacity  "******" :storage_performance  "******" :project_purpose  "******" &gt; &gt; :collection -cascade-contained-asset-index "true" -contained-asset-index "true" -unique-name-index "true"  "true" :type  "application/arc-asset-collection" 
   called by: 08-Feb-2024 13:19:05.112 [0.012 sec(s) ago]: http: from: /192.168.65.1, request: /__mflux_svc__ vars:  select headers: [User-Agent=Ruby, Connection=keep-alive, Host=0.0.0.0:8888]
   called by: 08-Feb-2024 13:19:05.112 [0.012 sec(s) ago]: network: ctime=08-Feb-2024 13:19:05.112, origin=/192.168.65.1, received=1463 [1.46 KB], sent=0 [0 bytes]
 	at arc.mf.server.Services.a(SourceFile:1696)
@@ -44,7 +44,7 @@ Context:
 	at arc.dUk.a(SourceFile:530)
 	at arc.dUk.run(SourceFile:478)
 	at arc.dUj.run(SourceFile:321)
-Caused by: arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'
+Caused by: arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'
 	at arc.aMb.b(SourceFile:2499)
 	at arc.aMb.a(SourceFile:2393)
 	at arc.aPQ.a(SourceFile:1558)
@@ -56,9 +56,9 @@ Caused by: arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/t
 	... 27 more
 
 Cause:
-arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data': 
+arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data': 
 Stack:
-arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'
+arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'
 	at arc.aMb.b(SourceFile:2499)
 	at arc.aMb.a(SourceFile:2393)
 	at arc.aPQ.a(SourceFile:1558)
@@ -100,8 +100,8 @@ arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/tigerdataNS/
       <sclass>arc.mf.server.service.Service$Exception</sclass>
       <sclass>java.lang.Exception</sclass>
       <sclass>java.lang.Throwable</sclass>
-      <message>The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'</message>
-      <stack>arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/tigerdataNS/big-dataNS already contains an asset named 'big-data'
+      <message>The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'</message>
+      <stack>arc.mf.modules.asset.Asset$ExNameExists: The namespace /td-test-001/test/tigerdataNS/big-dataNS already contains an asset named 'big-data'
 	at arc.aMb.b(SourceFile:2499)
 	at arc.aMb.a(SourceFile:2393)
 	at arc.aPQ.a(SourceFile:1558)

--- a/spec/fixtures/files/asset_update_request.xml
+++ b/spec/fixtures/files/asset_update_request.xml
@@ -5,7 +5,7 @@
       <id>1234</id>
       <meta>
         <tigerdata:project>
-          <ProjectDirectory>/td-test-001/tigerdataNS/big-data</ProjectDirectory>
+          <ProjectDirectory>/td-test-001/test/tigerdataNS/big-data</ProjectDirectory>
           <Title>Danger Cat</Title>
           <Description>a random description</Description>
           <Status>pending</Status>

--- a/spec/models/mediaflux/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/namespace_destroy_request_spec.rb
@@ -10,20 +10,21 @@ RSpec.describe Mediaflux::NamespaceDestroyRequest, type: :model, connect_to_medi
     it "deletes a namespace and everything inside of it" do
       mediaflux_id = valid_project.save_in_mediaflux(session_id: session_id)
       expect(mediaflux_id).not_to be_nil
-      namespace_list = Mediaflux::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
+      parent_namespace = Mediaflux::Connection.root_namespace
+      namespace_list = ::Mediaflux::NamespaceListRequest.new(session_token: session_id, parent_namespace: ).namespaces
       namespace_names = namespace_list.pluck(:name)
       expect(namespace_names).to include(namespace)
 
       # Destroy the namespace of the project and everything in it
-      described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy
-      namespace_list = Mediaflux::NamespaceListRequest.new(session_token: session_id, parent_namespace: "/td-test-001/tigerdataNS").namespaces
+      described_class.new(session_token: session_id, namespace: "#{parent_namespace}/#{namespace}").destroy
+      namespace_list = Mediaflux::NamespaceListRequest.new(session_token: session_id, parent_namespace: ).namespaces
       namespace_names = namespace_list.pluck(:name)
       expect(namespace_names).not_to include(namespace)
 
       # Should raise an error when attempting to destroy a namespace that does not exist
-      expect { described_class.new(session_token: session_id, namespace: "/td-test-001/tigerdataNS/#{namespace}").destroy }.to raise_error do |error|
+      expect { described_class.new(session_token: session_id, namespace: "#{parent_namespace}/#{namespace}").destroy }.to raise_error do |error|
         expect(error).to be_a(StandardError)
-        expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace /td-test-001/tigerdataNS/#{namespace} does not exist or is not accessible")
+        expect(error.message).to include("call to service 'asset.namespace.hard.destroy' failed: The namespace #{parent_namespace}/#{namespace} does not exist or is not accessible")
       end
     end
   end

--- a/spec/models/project_accumulator_spec.rb
+++ b/spec/models/project_accumulator_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ProjectAccumulator, connect_to_mediaflux: true do
       ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
       project_accumulators = described_class.new(project: project_in_mediaflux, session_id: session_id)
       project_accumulators.create!
-
       expect(project_accumulators.create!).to eq(false)
     end
   end

--- a/spec/services/test_project_generator_spec.rb
+++ b/spec/services/test_project_generator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TestProjectGenerator, connect_to_mediaflux: true do
         id: project.mediaflux_id
       )      
       metadata_query.resolve
-      expect(metadata_query.metadata[:path]).to eq "/td-test-001/tigerdata/test-project-00001"
+      expect(metadata_query.metadata[:path]).to eq "/td-test-001/test/tigerdata/test-project-00001"
       Mediaflux::AssetDestroyRequest.new(session_token: user.mediaflux_session, collection: project.mediaflux_id, members: true).resolve
     end
   end


### PR DESCRIPTION
Currently the root namespace is being destroyed, but that does not delete the collection since it is located in the upper namespace

![Screenshot 2024-07-19 at 3 21 10 PM](https://github.com/user-attachments/assets/adf53ac0-048c-437c-8a8f-dab3cef2cf6b)

refs #828 