### PR TITLE
Do not reinstall dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
         POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
-      - install_dependencies
       - persist_to_workspace:
           root: &root '~/tiger_data'
           paths: '*'
@@ -90,7 +89,6 @@ jobs:
         POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
-      - install_dependencies
       - persist_to_workspace:
           root: &root '~/tiger_data'
           paths: '*'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ commands:
           key: *yarn_key
           paths:
             - ~/.cache/yarn
+            
   restore_cache:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 commands:
-
   install_dependencies:
     steps:
       - run: sudo apt update && sudo apt install postgresql-client libmsgpack-dev libpq-dev
@@ -27,6 +26,13 @@ commands:
           key: *yarn_key
           paths:
             - ~/.cache/yarn
+  restore_cache:
+    steps:
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          key: &yarn_key tiger_data-yarn-cimg-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
 
   run_mediaflux:
     steps:
@@ -67,6 +73,7 @@ jobs:
         POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
+      - restore_cache
       - persist_to_workspace:
           root: &root '~/tiger_data'
           paths: '*'
@@ -89,6 +96,7 @@ jobs:
         POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
+      - restore_cache
       - persist_to_workspace:
           root: &root '~/tiger_data'
           paths: '*'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,9 @@ commands:
   restore_cache:
     steps:
       - restore_cache:
-          name: Restore Yarn Package Cache
-          key: &yarn_key tiger_data-yarn-cimg-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
+          keys: 
+            - &yarn_key tiger_data-yarn-cimg-{{ checksum "yarn.lock" }}
+            - &gem_key tiger_data-cimg-{{ checksum "Gemfile.lock.bak" }}
 
   run_mediaflux:
     steps:


### PR DESCRIPTION
The dependencies should be installed in the build step and then cached. We should not need to reinstall them in the lint and test parts of the build