### PR TITLE
ProjectMediaflux#update now sets updated_on/updated_by

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -163,8 +163,8 @@ class Project < ApplicationRecord
     Project.where("(metadata_json @> ? :: jsonb) OR (metadata_json @> ? :: jsonb)", query_ro, query_rw)
   end
 
-  def save_in_mediaflux(session_id:)
-    ProjectMediaflux.save(project: self, session_id: session_id)
+  def save_in_mediaflux(user:)
+    ProjectMediaflux.save(project: self, user: user)
   end
 
   def created_by_user

--- a/app/services/test_project_generator.rb
+++ b/app/services/test_project_generator.rb
@@ -11,8 +11,7 @@ class TestProjectGenerator
 
   def generate
     project = create_project
-    session_id = user.mediaflux_session
-    project.save_in_mediaflux(session_id:)
+    project.save_in_mediaflux(user: user)
     project.save!
     project
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -69,7 +69,7 @@ namespace :projects do
 
     project_id = args[:project_id]
     project = Project.find(project_id)
-    asset_id = project.save_in_mediaflux(session_id: user.mediaflux_session)
+    asset_id = project.save_in_mediaflux(user: user)
     puts "Mediaflux asset #{asset_id} updated"
   end
 

--- a/spec/jobs/activate_project_job_spec.rb
+++ b/spec/jobs/activate_project_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActivateProjectJob, connect_to_mediaflux: true, type: :job do
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi, status: Project::APPROVED_STATUS) }
 
   before do
-    ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+    ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
   end
 
   describe "#perform_now" do

--- a/spec/jobs/file_inventory_cleanup_job_spec.rb
+++ b/spec/jobs/file_inventory_cleanup_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FileInventoryCleanupJob, connect_to_mediaflux: true, type: :job d
   let(:eight_days_ago) { Time.current.in_time_zone("America/New_York") - 8.days }
 
   before do
-    ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+    ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
   end
 
   describe "#perform_now" do

--- a/spec/jobs/file_inventory_job_spec.rb
+++ b/spec/jobs/file_inventory_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FileInventoryJob, connect_to_mediaflux: true do
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi) }
 
   before do
-    ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+    ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
   end
 
   describe "#perform_later" do

--- a/spec/models/mediaflux/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/asset_metadata_request_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Mediaflux::AssetMetadataRequest, type: :model do
 
       before do
         # create a project in mediaflux
-        valid_project.mediaflux_id = ProjectMediaflux.create!(project: valid_project, session_id: session_token)
+        valid_project.mediaflux_id = ProjectMediaflux.create!(project: valid_project, user: current_user)
         ProjectAccumulator.new(project: valid_project, session_id: session_token).create!
       end
 

--- a/spec/models/mediaflux/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/namespace_destroy_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Mediaflux::NamespaceDestroyRequest, type: :model, connect_to_medi
   let(:session_id) { sponsor_user.mediaflux_session }
   context "when a namespace exists" do
     it "deletes a namespace and everything inside of it" do
-      mediaflux_id = valid_project.save_in_mediaflux(session_id: session_id)
+      mediaflux_id = valid_project.save_in_mediaflux(user: sponsor_user)
       expect(mediaflux_id).not_to be_nil
       parent_namespace = Mediaflux::Connection.root_namespace
       namespace_list = ::Mediaflux::NamespaceListRequest.new(session_token: session_id, parent_namespace: ).namespaces

--- a/spec/models/mediaflux/project_approve_request_spec.rb
+++ b/spec/models/mediaflux/project_approve_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mediaflux::ProjectApproveRequest, type: :model, connect_to_mediaf
   let(:session_id) { approver.mediaflux_session }
   let(:approved_project) do
     project = FactoryBot.create :approved_project
-    mediaflux_id = project.save_in_mediaflux(session_id: )
+    mediaflux_id = project.save_in_mediaflux(user: approver)
     data_sponsor = User.find_by(uid: project.metadata_model.data_sponsor)
     ProvenanceEvent.generate_submission_events(project: project, user: data_sponsor)
     project.metadata_model.project_directory = "approved_project"

--- a/spec/models/mediaflux/time_spec.rb
+++ b/spec/models/mediaflux/time_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mediaflux::Time do
     describe "#convert", connect_to_mediaflux: true do
       it "converts mediaflux time objects to utc before converting to america/new_york" do
         project = FactoryBot.create(:project_with_doi)
-        ProjectMediaflux.create!(project: project, session_id: current_user.mediaflux_session)
+        ProjectMediaflux.create!(project: project, user: current_user)
         metadata = Mediaflux::AssetMetadataRequest.new(
           session_token: current_user.mediaflux_session,
           id: project.mediaflux_id

--- a/spec/models/project_accumulator_spec.rb
+++ b/spec/models/project_accumulator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProjectAccumulator, connect_to_mediaflux: true do
 
   describe "#create!" do
     it "creates accumulators for the project" do
-      project_id = ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+      project_id = ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
       project_accumulators = described_class.new(project: project_in_mediaflux, session_id: session_id)
       proj_accum = project_accumulators.create!
       metadata = Mediaflux::AssetMetadataRequest.new(session_token: session_id, id: project_id).metadata
@@ -20,7 +20,7 @@ RSpec.describe ProjectAccumulator, connect_to_mediaflux: true do
     end
 
     it "does not create accumulators if they already exist" do
-      ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+      ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
       project_accumulators = described_class.new(project: project_in_mediaflux, session_id: session_id)
       project_accumulators.create!
       expect(project_accumulators.create!).to eq(false)
@@ -29,14 +29,14 @@ RSpec.describe ProjectAccumulator, connect_to_mediaflux: true do
 
   describe "#validate" do
     it "returns true if the collection has the expected accumulators" do
-      ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+      ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
       project_accumulators = described_class.new(project: project_in_mediaflux, session_id: session_id)
       project_accumulators.create!
       expect(project_accumulators.validate).to eq(true)
     end
 
     it "returns an array of accumulators if the collection does not have all expected accumulators" do
-      ProjectMediaflux.create!(session_id: user.mediaflux_session, project: project_in_mediaflux)
+      ProjectMediaflux.create!(user: user, project: project_in_mediaflux)
       expect(described_class.new(project: project_in_mediaflux, session_id: session_id).validate).to be_a(Array)
     end
   end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -123,4 +123,26 @@ RSpec.describe ProjectMediaflux, type: :model do
       end
     end
   end
+
+  describe "#update", connect_to_mediaflux: true do
+    before do
+      described_class.create!(project: project, user: current_user)
+    end
+    it "defaults updated_on/by when not provided" do
+      project.metadata_model.updated_on = nil
+      project.metadata_model.updated_by = nil
+      described_class.update(project: project, user: current_user)
+      expect(project.metadata_model.updated_on).not_to be nil
+      expect(project.metadata_model.updated_by).not_to be nil
+    end
+
+    it "honors updated_on/by values when provided" do
+      updated_on = Time.current.in_time_zone("America/New_York").iso8601
+      project.metadata_model.updated_on = updated_on
+      project.metadata_model.updated_by = "user123"
+      described_class.update(project: project, user: current_user)
+      expect(project.metadata_model.updated_on).to eq updated_on
+      expect(project.metadata_model.updated_by).to eq "user123"
+    end
+  end
 end

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ProjectMediaflux, type: :model do
       end
 
       context "when the parent colllection does not exist" do
-        let(:mediaflux_id) { described_class.create!(project: project,user: current_user) }
+        let(:mediaflux_id) { described_class.create!(project: project, user: current_user) }
         let(:mediaflux_metadata) do
           Mediaflux::AssetMetadataRequest.new(
                              session_token: current_user.mediaflux_session,
@@ -89,7 +89,6 @@ RSpec.describe ProjectMediaflux, type: :model do
       it "should raise a MetadataError if project is invalid" do
         mediaflux_id = 1001
         project.approve!(mediaflux_id: mediaflux_id, current_user: current_user)
-        session_token = current_user.mediaflux_session
 
         # raise a metadata error & log what specific required fields are missing when writing a project to mediaflux
         # rubocop:disable Style/MultilineBlockChain
@@ -109,7 +108,6 @@ RSpec.describe ProjectMediaflux, type: :model do
       it "should raise a error if any error occurs in mediaflux" do
         mediaflux_id = 1001
         incomplete_project.approve!(mediaflux_id: mediaflux_id, current_user: current_user)
-        session_token = current_user.mediaflux_session
 
         # raise an error & log what was returned from mediaflux
         # rubocop:disable Style/MultilineBlockChain

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -173,17 +173,17 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
     let(:project) { FactoryBot.create(:project_with_doi) }
     it "calls ProjectMediaflux to create the project and save the id" do
       expect(project.mediaflux_id).to be nil
-      project.save_in_mediaflux(session_id: user.mediaflux_session)
+      project.save_in_mediaflux(user: user)
       expect(project.mediaflux_id).not_to be nil
     end
 
     context "when the projects has already beed saved" do
       before do
-        project.save_in_mediaflux(session_id: user.mediaflux_session)
+        project.save_in_mediaflux(user: user)
       end
       it "calls out to mediuaflux with an update " do
         project.metadata_model.title = "New title"
-        expect { project.save_in_mediaflux(session_id: user.mediaflux_session) }.not_to raise_error
+        expect { project.save_in_mediaflux(user: user) }.not_to raise_error
       end
     end
   end
@@ -339,8 +339,7 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
     project.create!(initial_metadata: project.metadata_model, user: current_user)
 
     # create a project in mediaflux
-    session_token = current_user.mediaflux_session
-    collection_id = project.save_in_mediaflux(session_id: session_token)
+    collection_id = project.save_in_mediaflux(user: current_user)
     project.approve!(mediaflux_id: collection_id, current_user: current_user)
 
     #validate that the collection id exists in mediaflux
@@ -359,8 +358,7 @@ RSpec.describe Project, type: :model, stub_mediaflux: true do
       project.create!(initial_metadata: project.metadata_model, user: current_user)
 
       # create a project in mediaflux
-      session_token = current_user.mediaflux_session
-      collection_id = project.save_in_mediaflux(session_id: session_token)
+      collection_id = project.save_in_mediaflux(user: current_user)
       project.approve!(mediaflux_id: collection_id, current_user: current_user)
 
       # change the doi so it will not match up when activated

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -148,10 +148,8 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true, js: true do
       let(:last_file) { file_list.reverse.find { |asset| asset.collection == false } }
 
       before do
-        session_id = sponsor_user.mediaflux_session
-
         # Create a project in mediaflux, attach an accumulator, and generate assests for the collection
-        project.save_in_mediaflux(session_id: session_id)
+        project.save_in_mediaflux(user: sponsor_user)
         TestAssetGenerator.new(user: sponsor_user, project_id: project.id, levels: 2, directory_per_level: 2, file_count_per_directory: 4).generate
       end
 

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe "Project Page", type: :system, stub_mediaflux: true do
         end
         expect(page).to have_content "New Project Request Received"
         project = Project.last
-        project.save_in_mediaflux(session_id: @session_id)
+        project.save_in_mediaflux(user: sponsor_user)
         expect(project.mediaflux_id).not_to be_blank
         expect(Mediaflux::AssetDestroyRequest.new(session_token: @session_id, collection: project.mediaflux_id, members: true).error?).to be_falsey
       end


### PR DESCRIPTION
Updated `ProjectMediaflux#update` to set the `updated_on` and `updated_by` with defaults when not provided in the metadata.

The change was small but I did change the method signature so I had to update a bunch of test to pass the `user` rather then the `session_id` and be able to calculate the defaults.

