### PR TITLE
Show aterm create script on the Approval screen

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -64,7 +64,7 @@
   .emulation {
     display: inline-flex;
   }
-  
+
   #emulation_bar {
     margin-left: 5px
   }
@@ -73,7 +73,7 @@
     @include dashboard-component;
     min-width: 40em;
     position: relative;
-  
+
     .btn-dark {
       margin-left: 0.5em;
       margin-bottom: 0.5em;
@@ -222,7 +222,7 @@
   }
 }
 
-#approve{ 
+#approve{
   .details{
     margin-left: 2em;
   }
@@ -279,7 +279,7 @@
   }
   dd{
     margin-bottom: .5rem;
-    
+
 
   }
   p {
@@ -296,7 +296,7 @@
     }
     -webkit-outer-spin-button, -webkit-inner-spin-button {
       display: none;
-      margin: 0; 
+      margin: 0;
     }
     [type=number]{
       -moz-appearance:textfield;
@@ -321,4 +321,12 @@
 .login button {
   background-color: #ffc107;
   border-color: #ffc107;
+}
+
+#create-script-text {
+  font-family: 'Courier New', Courier, monospace;
+  background-color: #f2f1f1;
+  margin-left: 35px;
+  margin-top: 15px;
+  margin-bottom: 15px;
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -201,6 +201,15 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def create_script
+    project_id = params[:id]
+    project = Project.find(project_id)
+    service = MediafluxScriptFactory.new(project: project)
+    respond_to do |format|
+      format.json { render json: {script: service.aterm_script} }
+    end
+  end
+
   private
 
     def build_new_project

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -15,12 +15,14 @@ import * as bootstrap from 'bootstrap';
 import { setTargetHtml } from './helper';
 import UserDatalist from './user_datalist';
 import { displayMediafluxVersion } from './mediafluxVersion';
+import { showCreateScript } from './atermScripts';
 
 // ActionCable Channels
 import '../channels';
 
 window.bootstrap = bootstrap;
 window.displayMediafluxVersion = displayMediafluxVersion;
+window.showCreateScript = showCreateScript;
 
 function initDataUsers() {
   function counterIncrement(counterId) {

--- a/app/javascript/entrypoints/atermScripts.js
+++ b/app/javascript/entrypoints/atermScripts.js
@@ -3,15 +3,15 @@ export function showCreateScript(url) {
   $('#create-script-btn').on('click', (el) => {
     $.ajax({
       type: 'GET',
-      url: url,
+      url,
       success(data) {
-        const lines = data.script.split("\n");
-        let atermScript = "";
-        for(var i=0; i < lines.length; i++) {
-          let line = lines[i];
-          let prefixSize = line.length - line.trimLeft().length;
-          let spaces = "&nbsp;".repeat(prefixSize)
-          atermScript += spaces + line + "<br/>";
+        const lines = data.script.split('\n');
+        let atermScript = '';
+        for (let i = 0; i < lines.length; i += 1) {
+          const line = lines[i];
+          const prefixSize = line.length - line.trimLeft().length;
+          const spaces = '&nbsp;'.repeat(prefixSize);
+          atermScript += `${spaces + line}<br/>`;
         }
         $('#create-script-text').html(atermScript);
       },

--- a/app/javascript/entrypoints/atermScripts.js
+++ b/app/javascript/entrypoints/atermScripts.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line import/prefer-default-export
+export function showCreateScript(url) {
+  $('#create-script-btn').on('click', (el) => {
+    $.ajax({
+      type: 'GET',
+      url: url,
+      success(data) {
+        const lines = data.script.split("\n");
+        let atermScript = "";
+        for(var i=0; i < lines.length; i++) {
+          let line = lines[i];
+          let prefixSize = line.length - line.trimLeft().length;
+          let spaces = "&nbsp;".repeat(prefixSize)
+          atermScript += spaces + line + "<br/>";
+        }
+        $('#create-script-text').html(atermScript);
+      },
+    });
+    el.preventDefault();
+  });
+}

--- a/app/models/mediaflux/root_collection_asset.rb
+++ b/app/models/mediaflux/root_collection_asset.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Mediaflux
   class RootCollectionAsset
-    attr_reader :error
+    attr_reader :error, :root_ns, :parent_collection, :parent_ns, :path
 
     # In the context of this class:
     #

--- a/app/services/mediaflux_script_factory.rb
+++ b/app/services/mediaflux_script_factory.rb
@@ -37,6 +37,12 @@ class MediafluxScriptFactory
       @metadata.departments.map { |department| ":Department \"#{department}\"" }
     end
 
+    def data_users
+      users = @metadata.ro_users.map { |user| ":DataUser \"#{user}\"" }
+      users += @metadata.rw_users.map { |user| ":DataUser \"#{user}\" -ReadOnly true" }
+      users
+    end
+
     # rubocop:disable Metrics/AbcSize
     def script_asset_create
       # Future enhancements:
@@ -61,6 +67,7 @@ class MediafluxScriptFactory
             :DataSponsor "#{@metadata.data_sponsor}"
             :DataManager "#{@metadata.data_manager}"
             #{department_fields.join(' ')}
+            #{data_users.join(' ')}
             :CreatedOn "#{created_on}"
             :CreatedBy "#{@metadata.created_by}"
             :ProjectID "#{@metadata.project_id}"

--- a/app/services/mediaflux_script_factory.rb
+++ b/app/services/mediaflux_script_factory.rb
@@ -45,8 +45,6 @@ class MediafluxScriptFactory
 
     # rubocop:disable Metrics/AbcSize
     def script_asset_create
-      # Future enhancements:
-      # * Include read-only and read-write users
       <<-ATERM
       # Create the namespace for the project
       asset.namespace.create :namespace #{project_namespace}

--- a/app/services/mediaflux_script_factory.rb
+++ b/app/services/mediaflux_script_factory.rb
@@ -1,91 +1,76 @@
 # frozen_string_literal: true
 
 class MediafluxScriptFactory
-  def project
-    @project ||= Project.find(@project_id)
+  def initialize(project:)
+    @project = project
+    @metadata = project.metadata_model
+
+    root_ns = Rails.configuration.mediaflux["api_root_collection_namespace"]
+    parent_collection = Rails.configuration.mediaflux["api_root_collection_name"]
+    @root_info = Mediaflux::RootCollectionAsset.new(session_token: nil, root_ns: root_ns, parent_collection: parent_collection)
   end
-  delegate :project_directory, to: :project
-  def project_parent
-    project.project_directory_parent_path
+
+  def aterm_script
+    prolog = "# Run these steps from Aterm to create a project in Mediaflux with its related components"
+    [prolog, script_asset_create].join("\r\n\r\n")
   end
-  alias path_id project_parent
-  delegate :metadata, to: :project
+
+  private
 
   def project_namespace
-    @project_namespace ||= "#{project_directory}NS"
+    Pathname.new(@root_info.parent_ns).join(@project.project_directory_short + "NS")
   end
 
-  def departments
-    metadata["departments"]
-  end
-
-  def department_fields
-    departments.map { |department| ":Department \"#{department}\"" }
-  end
-
-  def created_on_metadata
-    project.metadata_json["created_on"]
-  end
-
-  def created_on_time
-    Time.zone.parse(created_on_metadata)
-  end
-
-  def created_on_formatted
-    created_on_time.strftime("%e-%b-%Y %H:%M:%S")
+  def project_parent_path
+    Pathname.new(@root_info.path)
   end
 
   def created_on
-    created_on_formatted.upcase
+    Mediaflux::Time.format_date_for_mediaflux(@metadata.created_on)
   end
 
-  def requested_by
-    project.metadata_model.created_by
+  def department_fields
+    @metadata.departments.map { |department| ":Department \"#{department}\"" }
   end
 
-  def request_date_time
-    project.metadata_model.created_on
-  end
-
-  def requested_date
-    Mediaflux::Time.format_date_for_mediaflux(request_date_time)
-  end
-
-  # rubocop:disable Metrics/AbcSize
-  def build_create_script
+  def script_asset_create
+    # TODO: handle read-only and read-write user
     <<-ATERM
-      # Run these steps from Aterm to create a project in Mediaflux with its related components
 
       # Create the namespace for the project
       asset.namespace.create :namespace #{project_namespace}
 
       # Create the collection asset for the project
       asset.create
-        :pid path=#{project_parent}
+        :pid path=#{project_parent_path}
         :namespace #{project_namespace}
-        :name #{project_directory}
+        :name #{@project.project_directory_short}
         :collection -unique-name-index true -contained-asset-index true -cascade-contained-asset-index true true
         :type "application/arc-asset-collection"
         :meta <
           :tigerdata:project <
-            :ProjectDirectory "#{project_directory}"
-            :Title "#{project.metadata_json['title']}"
-            :Description "#{project.metadata_json['description']}"
-            :Status "#{project.metadata_json['status']}"
-            :DataSponsor "#{project.metadata_json['data_sponsor']}"
-            :DataManager "#{project.metadata_json['data_manager']}"
+            :ProjectDirectory "#{@metadata.project_directory}"
+            :Title "#{@metadata.title}"
+            :Description "#{@metadata.description}"
+            :Status "#{@metadata.status}"
+            :DataSponsor "#{@metadata.data_sponsor}"
+            :DataManager "#{@metadata.data_manager}"
             #{department_fields.join(' ')}
             :CreatedOn "#{created_on}"
-            :CreatedBy "#{project.metadata_json['created_by']}"
-            :ProjectID "#{project.metadata_json['project_id']}"
-            :StorageCapacity < :Size "#{project.metadata_json['storage_capacity']['size']['requested']}>" :Unit #{project.metadata_json['storage_capacity']['unit']['requested']}"
-            :StoragePerformance "#{project.metadata_json['storage_performance_expectations']['requested']}"
-            :ProjectPurpose "#{project.metadata_json['project_purpose']}"
-            :Submission < :RequestedBy "#{requested_by}" :RequestDateTime "#{requested_date}" >
-            :SchemaVersion "#{project.metadata['schema_version']}"
+            :CreatedBy "#{@metadata.created_by}"
+            :ProjectID "#{@metadata.project_id}"
+            :StorageCapacity < :Size #{@metadata.storage_capacity['size']['requested']} :Unit "#{@metadata.storage_capacity['unit']['requested']}" >
+            :Performance "#{@metadata.storage_performance_expectations['requested']}"
+            :ProjectPurpose "#{@metadata.project_purpose}"
+            :Submission < :RequestedBy "#{@metadata.created_by}" :RequestDateTime "#{created_on}" >
+            :SchemaVersion "#{@metadata.schema_version}"
           >
         >
+    ATERM
+  end
 
+  def script_accumulators
+    <<-ATERM
     # Define accumulator for file count
     asset.collection.accumulator.add
       :id path=#{path_id}
@@ -103,16 +88,15 @@ class MediafluxScriptFactory
       :name #{project_directory}-size
         :type content.all.size
       >
+    ATERM
+  end
 
+  def script_quotas
+    <<-ATERM
     # Define storage quota
     asset.collection.quota.set
       :id path=#{path_id}
       :quota < :allocation 500 GB :on-overflow fail :description "500 GB quota for #{project_directory}>"
     ATERM
-  end
-  # rubocop:enable Metrics/AbcSize
-
-  def initialize(project_id)
-    @project_id = project_id
   end
 end

--- a/app/services/mediaflux_script_factory.rb
+++ b/app/services/mediaflux_script_factory.rb
@@ -15,8 +15,6 @@ class MediafluxScriptFactory
     [prolog, script_asset_create].join("\r\n\r\n")
   end
 
-  private
-
   def project_namespace
     Pathname.new(@root_info.parent_ns).join(@project.project_directory_short + "NS")
   end
@@ -25,17 +23,21 @@ class MediafluxScriptFactory
     Pathname.new(@root_info.path)
   end
 
-  def created_on
-    Mediaflux::Time.format_date_for_mediaflux(@metadata.created_on)
-  end
+  private
 
-  def department_fields
-    @metadata.departments.map { |department| ":Department \"#{department}\"" }
-  end
+    def created_on
+      Mediaflux::Time.format_date_for_mediaflux(@metadata.created_on)
+    end
 
-  def script_asset_create
-    # TODO: handle read-only and read-write user
-    <<-ATERM
+    def department_fields
+      @metadata.departments.map { |department| ":Department \"#{department}\"" }
+    end
+
+    def script_asset_create
+      # Future enhancements:
+      # * Include read-only and read-write users
+      # * Include quota as part of the project creation
+      <<-ATERM
 
       # Create the namespace for the project
       asset.namespace.create :namespace #{project_namespace}
@@ -67,10 +69,10 @@ class MediafluxScriptFactory
           >
         >
     ATERM
-  end
+    end
 
-  def script_accumulators
-    <<-ATERM
+    def script_accumulators
+      <<-ATERM
     # Define accumulator for file count
     asset.collection.accumulator.add
       :id path=#{path_id}
@@ -89,14 +91,14 @@ class MediafluxScriptFactory
         :type content.all.size
       >
     ATERM
-  end
+    end
 
-  def script_quotas
-    <<-ATERM
+    def script_quotas
+      <<-ATERM
     # Define storage quota
     asset.collection.quota.set
       :id path=#{path_id}
       :quota < :allocation 500 GB :on-overflow fail :description "500 GB quota for #{project_directory}>"
     ATERM
-  end
+    end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -12,10 +12,10 @@ Project Details:
 
 <% alert_class = if @project.pending?
                    "alert-warning"
-                 else 
+                 else
                    "alert-success"
                  end %>
-  
+
 <div class="alert <%= alert_class %>" role="alert">
   <dl>
   <dt>Status</dt> <dd><%= @project.status %></dd>
@@ -77,7 +77,7 @@ Project Details:
 </div>
 
 <div class="details">
-  <%= if @project.pending? 
+  <%= if @project.pending?
     render partial: "pending_details"
   else
     render partial: "approved_details"
@@ -104,12 +104,21 @@ Project Details:
 
 <div class="details">
   <% if current_user.eligible_sysadmin? %>
-    <% if @project.pending? %> 
+    <% if @project.pending? %>
       <%= link_to "Approve Project", project_approve_path(@project), class: "btn btn-primary btn-sm" %>
       <%= link_to "Deny Project", "", class: "btn btn-secondary btn-sm" %>
+      <%= link_to " View Create Script", "#", class: "bi bi-code btn btn-secondary btn-sm", id: "create-script-btn" %>
     <% end %>
     <%= link_to "Review Contents", project_contents_path(@project), class: "btn btn-primary btn-sm" %>
     <%= link_to "Return to Dashboard", root_path, class: "btn btn-return btn-sm" %>
   <% end %>
 </div>
+
+<!-- this div is populated by the AJAX below -->
+<div id="create-script-text"></div>
 </show>
+
+<script type="module">
+  // Make the AJAX call to fetch the aterm script
+  showCreateScript('<%= project_create_script_path(format: "json") %>');
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   get "projects/:id/revision_confirmation", to: "projects#revision_confirmation", as: :project_revision_confirmation
   get "projects/file_list_download/:job_id", to: "projects#file_list_download", as: :project_file_list_download
   get "projects/:id/approval_received", to: "projects#approval_received", as: :project_approval_received
+  get "projects/:id/create-script", to: "projects#create_script", as: :project_create_script
 
   namespace :api do
     namespace :v0 do

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -73,15 +73,17 @@ namespace :projects do
     puts "Mediaflux asset #{asset_id} updated"
   end
 
-  desc "Outputs to a file an aterm script to create a project (namespace and collection) in Mediaflux"
+  desc "Outputs to a file an aterm script to create a project in Mediaflux"
   task :create_script, [:project_id] => [:environment] do |_, args|
     project_id = args[:project_id]
-    service = MediafluxScriptFactory.new(project_id: project_id)
-    script = service.build_create_script
-
+    project = Project.find(project_id)
+    service = MediafluxScriptFactory.new(project: project)
     file_name = "project_create_#{project.id}.txt"
     puts "Saving script to #{file_name}"
-    File.write(file_name, script)
+    puts "=="
+    puts service.aterm_script
+    puts ""
+    # File.write(file_name, service.aterm_script)
   end
 
   task :download_file_list, [:netid, :project_id] => [:environment] do |_, args|

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -73,17 +73,12 @@ namespace :projects do
     puts "Mediaflux asset #{asset_id} updated"
   end
 
-  desc "Outputs to a file an aterm script to create a project in Mediaflux"
+  desc "Outputs to the console the Aterm script to create a project in Mediaflux"
   task :create_script, [:project_id] => [:environment] do |_, args|
     project_id = args[:project_id]
     project = Project.find(project_id)
     service = MediafluxScriptFactory.new(project: project)
-    file_name = "project_create_#{project.id}.txt"
-    puts "Saving script to #{file_name}"
-    puts "=="
     puts service.aterm_script
-    puts ""
-    # File.write(file_name, service.aterm_script)
   end
 
   task :download_file_list, [:netid, :project_id] => [:environment] do |_, args|

--- a/spec/services/mediaflux_script_factory_spec.rb
+++ b/spec/services/mediaflux_script_factory_spec.rb
@@ -26,6 +26,13 @@ describe MediafluxScriptFactory do
       expect(output).to include(":Performance \"#{project.metadata_model.storage_performance_expectations[:requested]}\"")
       expect(output).to include(":ProjectPurpose \"#{project.metadata_model.project_purpose}\"")
       expect(output).to include(":SchemaVersion \"#{project.metadata_model.schema_version}\"")
+      # Quota
+      expect(output).to include(":quota")
+      expect(output).to include(":description \"Project Quota\"")
+      # Accumulators
+      expect(output).to include("asset.collection.accumulator.add")
+      expect(output).to include(":name #{project.project_directory_short}-count")
+      expect(output).to include(":name #{project.project_directory_short}-size")
     end
   end
 end

--- a/spec/services/mediaflux_script_factory_spec.rb
+++ b/spec/services/mediaflux_script_factory_spec.rb
@@ -2,73 +2,30 @@
 require "rails_helper"
 
 describe MediafluxScriptFactory do
-  subject(:mediaflux_service) { described_class.new(project_id) }
   let(:project) { FactoryBot.create(:approved_project) }
-  let(:project_id) { project.id }
+  subject(:mediaflux_service) { described_class.new(project: project) }
 
-  describe "#department_fields" do
-    let(:output) { mediaflux_service.department_fields }
-
-    it "concatenates the names of all department fields" do
-      expect(output).not_to be nil
-      expect(output).to include(":Department \"PRDS\"")
-      expect(output).to include(":Department \"RDSS\"")
-    end
-  end
-
-  describe "#created_on" do
-    let(:output) { mediaflux_service.created_on }
-
-    it "formats the date into a valid DateTime stamp" do
-      expect(output).not_to be nil
-      parsed = DateTime.parse(output)
-      expect(parsed).to be_a(DateTime)
-    end
-  end
-
-  describe "#requested_by" do
-    let(:output) { mediaflux_service.requested_by }
-
-    it "accesses the user ID of the requesting user" do
-      expect(output).not_to be nil
-      user = User.find_by(uid: output)
-      expect(user).not_to be nil
-      expect(user.uid).to eq(output)
-    end
-  end
-
-  describe "#requested_date" do
-    let(:output) { mediaflux_service.requested_date }
-
-    it "formats the date into a valid DateTime stamp" do
-      expect(output).not_to be nil
-      parsed = DateTime.parse(output)
-      expect(parsed).to be_a(DateTime)
-    end
-  end
-
-  describe "#build_create_script" do
-    let(:output) { mediaflux_service.build_create_script }
+  describe "#aterm_script" do
+    let(:output) { mediaflux_service.aterm_script }
 
     it "generates the Mediaflux API script for creating a project" do
-      expect(output).to be_a(String)
-      expect(output).to include(":pid path=#{project.project_directory_parent_path}")
-      expect(output).to include(":namespace #{project.project_directory_parent_path}")
-      expect(output).to include(":name #{project.project_directory_parent_path}")
+      expect(output).to include(":pid path=#{mediaflux_service.project_parent_path}")
+      expect(output).to include(":namespace #{mediaflux_service.project_namespace}")
+      expect(output).to include(":name #{project.project_directory_short}")
       # Metadata
-      expect(output).to include(":ProjectDirectory \"#{project.project_directory}\"")
-      expect(output).to include(":Title \"#{project.metadata[:title]}\"")
-      expect(output).to include(":Description \"#{project.metadata[:description]}\"")
-      expect(output).to include(":Status \"#{project.metadata[:status]}\"")
-      expect(output).to include(":DataSponsor \"#{project.metadata[:data_sponsor]}\"")
-      expect(output).to include(":DataManager \"#{project.metadata[:data_manager]}\"")
-      expect(output).to include(":CreatedBy \"#{project.metadata[:created_by]}\"")
-      expect(output).to include(":ProjectID \"#{project.metadata[:project_id]}\"")
-      expect(output).to include(":StorageCapacity < :Size \"#{project.metadata[:storage_capacity][:size][:requested]}>\"")
-      expect(output).to include(":Unit #{project.metadata[:storage_capacity][:unit][:requested]}\"")
-      expect(output).to include(":StoragePerformance \"#{project.metadata[:storage_performance_expectations][:requested]}\"")
-      expect(output).to include(":ProjectPurpose \"#{project.metadata[:project_purpose]}\"")
-      expect(output).to include(":SchemaVersion \"#{project.metadata[:schema_version]}\"")
+      expect(output).to include(":ProjectDirectory \"#{project.metadata_model.project_directory}\"")
+      expect(output).to include(":Title \"#{project.metadata_model.title}\"")
+      expect(output).to include(":Description \"#{project.metadata_model.description}\"")
+      expect(output).to include(":Status \"#{project.metadata_model.status}\"")
+      expect(output).to include(":DataSponsor \"#{project.metadata_model.data_sponsor}\"")
+      expect(output).to include(":DataManager \"#{project.metadata_model.data_manager}\"")
+      expect(output).to include(":CreatedBy \"#{project.metadata_model.created_by}\"")
+      expect(output).to include(":ProjectID \"#{project.metadata_model.project_id}\"")
+      expect(output).to include(":StorageCapacity < :Size #{project.metadata_model.storage_capacity[:size][:requested]}")
+      expect(output).to include(":Unit \"#{project.metadata_model.storage_capacity[:unit][:requested]}\"")
+      expect(output).to include(":Performance \"#{project.metadata_model.storage_performance_expectations[:requested]}\"")
+      expect(output).to include(":ProjectPurpose \"#{project.metadata_model.project_purpose}\"")
+      expect(output).to include(":SchemaVersion \"#{project.metadata_model.schema_version}\"")
     end
   end
 end


### PR DESCRIPTION
Refactored the `MediafluxScriptFactory` to use the new metadata and root values and then hook it to the Approval screen so that we can surface this information to people creating projects in Mediaflux (see screenshot below).

The script will probably need tweaking based on Chuck's feedback, but the general idea is there.

![Screenshot 2024-07-24 at 1 24 20 PM](https://github.com/user-attachments/assets/b002987a-fe80-43fa-b2d9-c8e9fe710464)
