### PR TITLE
Save to a file the Aterm script for project creation

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -81,6 +81,16 @@ namespace :projects do
     puts service.aterm_script
   end
 
+  desc "Outputs to a file the Aterm script to create a project in Mediaflux"
+  task :create_script_file, [:project_id] => [:environment] do |_, args|
+    project_id = args[:project_id]
+    project = Project.find(project_id)
+    service = MediafluxScriptFactory.new(project: project)
+    file_name = "project_create_#{project.id}.txt"
+    puts "Saving script to #{file_name}"
+    File.write(file_name, service.aterm_script)
+  end
+
   task :download_file_list, [:netid, :project_id] => [:environment] do |_, args|
     netid = args[:netid]
     user = User.where(uid: netid).first


### PR DESCRIPTION
Re-added rake task to save to a file the aterm script to create a project

In https://github.com/pulibrary/tiger-data-app/pull/859 I changed the rake task to always output the script to the console. This new PR allows us to do both: `rake projects:create_script_file` saves to a file whereas`rake projects:create_script` outputs to the console.