### PR TITLE
HTTP headers for Mediaflux authentication

### DIFF
--- a/app/models/mediaflux/request.rb
+++ b/app/models/mediaflux/request.rb
@@ -176,9 +176,7 @@ module Mediaflux
       def set_authentication_headers(request)
         return if @session_user.nil?
 
-        request["TIGERDATA_NETID"] = @session_user.uid
-        request["TIGERDATA_DOMAIN"] = "princeton.edu"
-        request["TIGERDATA_TIMEOUT"] = "tbd"
+        request["mediaflux.sso.user"] = @session_user.uid
       end
     end
 end

--- a/spec/models/mediaflux/asset_exist_request_headers_spec.rb
+++ b/spec/models/mediaflux/asset_exist_request_headers_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::AssetExistRequest, type: :model, connect_to_mediaflux: false do
+  let(:user) { FactoryBot.create(:user) }
+  let(:session_token) { user.mediaflux_session }
+  let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
+  let(:name) { FFaker::InternetSE.company_name_single_word }
+  let(:login_response) do
+    <<-XML_BODY
+      <?xml version="1.0" encoding="UTF-8"?>
+      <response>
+          <reply type="result">
+              <result>
+                  <session id="54" timeout="1800" wallet="true">test-session-token</session>
+                  <locale>en-US</locale>
+                  <user username="manager">
+                      <name />
+                  </user>
+              </result>
+          </reply>
+      </response>
+    XML_BODY
+  end
+
+  let(:asset_exists_response) do
+    <<-XML_BODY
+      <?xml version="1.0" encoding="UTF-8"?>
+      <response>
+          <reply type="result">
+              <result>
+                  <exists>true</exists>
+              </result>
+          </reply>
+      </response>
+    XML_BODY
+  end
+
+  before do
+    WebMock.enable!
+    WebMock.disable_net_connect!
+
+    stub_request(:post, "http://0.0.0.0:8888/__mflux_svc__").with(
+      body: /<service name="system.logon">/
+    ).to_return(status: 200, body: login_response)
+
+    stub_request(:post, "http://0.0.0.0:8888/__mflux_svc__").with(
+      body: /<service name="asset.exists"/,
+      headers: { 'mediaflux.sso.user' => user.uid },  # Our custom HTTP header
+    ).to_return(status: 200, body: asset_exists_response)
+  end
+
+  context "when we pass a user to the class" do
+    it "passes the custom HTTP headers to Mediaflux" do
+      subject = described_class.new(session_token: nil, session_user: user, path: namespace_root)
+      expect(subject.exist?).to be true
+    end
+  end
+
+end

--- a/spec/models/mediaflux/asset_exist_request_headers_spec.rb
+++ b/spec/models/mediaflux/asset_exist_request_headers_spec.rb
@@ -3,58 +3,21 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::AssetExistRequest, type: :model, connect_to_mediaflux: false do
   let(:user) { FactoryBot.create(:user) }
-  let(:session_token) { user.mediaflux_session }
   let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
-  let(:name) { FFaker::InternetSE.company_name_single_word }
-  let(:login_response) do
-    <<-XML_BODY
-      <?xml version="1.0" encoding="UTF-8"?>
-      <response>
-          <reply type="result">
-              <result>
-                  <session id="54" timeout="1800" wallet="true">test-session-token</session>
-                  <locale>en-US</locale>
-                  <user username="manager">
-                      <name />
-                  </user>
-              </result>
-          </reply>
-      </response>
-    XML_BODY
-  end
 
-  let(:asset_exists_response) do
-    <<-XML_BODY
-      <?xml version="1.0" encoding="UTF-8"?>
-      <response>
-          <reply type="result">
-              <result>
-                  <exists>true</exists>
-              </result>
-          </reply>
-      </response>
-    XML_BODY
-  end
-
-  before do
-    WebMock.enable!
-    WebMock.disable_net_connect!
-
-    stub_request(:post, "http://0.0.0.0:8888/__mflux_svc__").with(
-      body: /<service name="system.logon">/
-    ).to_return(status: 200, body: login_response)
-
-    stub_request(:post, "http://0.0.0.0:8888/__mflux_svc__").with(
-      body: /<service name="asset.exists"/,
-      headers: { 'mediaflux.sso.user' => user.uid },  # Our custom HTTP header
-    ).to_return(status: 200, body: asset_exists_response)
-  end
-
-  context "when we pass a user to the class" do
-    it "passes the custom HTTP headers to Mediaflux" do
+  context "when we give a user to the class" do
+    it "sends the custom HTTP headers to Mediaflux" do
       subject = described_class.new(session_token: nil, session_user: user, path: namespace_root)
-      expect(subject.exist?).to be true
+      http_request = subject.send("http_request")
+      expect(http_request["mediaflux.sso.user"]).to eq user.uid
     end
   end
 
+  context "when we give a session token to the class" do
+    it "does NOT send the custom HTTP headers to Mediaflux" do
+      subject = described_class.new(session_token: user.mediaflux_session, session_user: nil, path: namespace_root)
+      http_request = subject.send("http_request")
+      expect(http_request["mediaflux.sso.user"]).to be nil
+    end
+  end
 end

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -41,32 +41,36 @@ end
 # Allow real connections to the Mediaflux server when a test is configured with
 # connect_to_mediaflux: true
 RSpec.configure do |config|
-  config.before(:each) do |ex|
-    if ex.metadata[:connect_to_mediaflux]
-      @original_api_host = Rails.configuration.mediaflux["api_host"]
-      Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
-      # Ensure the latest mediaflux schema has been loaded before running the tests
-      require "rake"
-      Rails.application.load_tasks
-      Rake::Task["schema:create"].invoke
-      reset_mediaflux_root
-    end
-  rescue StandardError => namespace_error
-    message = "Bypassing pre-test cleanup error, #{namespace_error.message}"
-    puts message # allow the message to show in CI output
-    Rails.logger.error(message)
-  end
+  # config.before(:each) do |ex|
+  #   puts "example eval"
+  #   if ex.metadata[:connect_to_mediaflux]
+  #     puts "  connecting to MF"
+  #     @original_api_host = Rails.configuration.mediaflux["api_host"]
+  #     Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
+  #     # Ensure the latest mediaflux schema has been loaded before running the tests
+  #     require "rake"
+  #     Rails.application.load_tasks
+  #     Rake::Task["schema:create"].invoke
+  #     reset_mediaflux_root
+  #   else
+  #     puts "  NOT connecting to MF"
+  #   end
+  # rescue StandardError => namespace_error
+  #   message = "Bypassing pre-test cleanup error, #{namespace_error.message}"
+  #   puts message # allow the message to show in CI output
+  #   Rails.logger.error(message)
+  # end
 
-  config.after(:each) do |ex|
-    if ex.metadata[:connect_to_mediaflux]
-      Rails.configuration.mediaflux["api_host"] = @original_api_host
-    end
-  end
+  # config.after(:each) do |ex|
+  #   if ex.metadata[:connect_to_mediaflux]
+  #     Rails.configuration.mediaflux["api_host"] = @original_api_host
+  #   end
+  # end
 
-  config.after(:suite)  do |_ex|
-    original_api_host = Rails.configuration.mediaflux["api_host"]
-    Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
-    reset_mediaflux_root
-    Rails.configuration.mediaflux["api_host"] = original_api_host
-  end
+  # config.after(:suite)  do |_ex|
+  #   original_api_host = Rails.configuration.mediaflux["api_host"]
+  #   Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
+  #   reset_mediaflux_root
+  #   Rails.configuration.mediaflux["api_host"] = original_api_host
+  # end
 end

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -41,36 +41,32 @@ end
 # Allow real connections to the Mediaflux server when a test is configured with
 # connect_to_mediaflux: true
 RSpec.configure do |config|
-  # config.before(:each) do |ex|
-  #   puts "example eval"
-  #   if ex.metadata[:connect_to_mediaflux]
-  #     puts "  connecting to MF"
-  #     @original_api_host = Rails.configuration.mediaflux["api_host"]
-  #     Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
-  #     # Ensure the latest mediaflux schema has been loaded before running the tests
-  #     require "rake"
-  #     Rails.application.load_tasks
-  #     Rake::Task["schema:create"].invoke
-  #     reset_mediaflux_root
-  #   else
-  #     puts "  NOT connecting to MF"
-  #   end
-  # rescue StandardError => namespace_error
-  #   message = "Bypassing pre-test cleanup error, #{namespace_error.message}"
-  #   puts message # allow the message to show in CI output
-  #   Rails.logger.error(message)
-  # end
+  config.before(:each) do |ex|
+    if ex.metadata[:connect_to_mediaflux]
+      @original_api_host = Rails.configuration.mediaflux["api_host"]
+      Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
+      # Ensure the latest mediaflux schema has been loaded before running the tests
+      require "rake"
+      Rails.application.load_tasks
+      Rake::Task["schema:create"].invoke
+      reset_mediaflux_root
+    end
+  rescue StandardError => namespace_error
+    message = "Bypassing pre-test cleanup error, #{namespace_error.message}"
+    puts message # allow the message to show in CI output
+    Rails.logger.error(message)
+  end
 
-  # config.after(:each) do |ex|
-  #   if ex.metadata[:connect_to_mediaflux]
-  #     Rails.configuration.mediaflux["api_host"] = @original_api_host
-  #   end
-  # end
+  config.after(:each) do |ex|
+    if ex.metadata[:connect_to_mediaflux]
+      Rails.configuration.mediaflux["api_host"] = @original_api_host
+    end
+  end
 
-  # config.after(:suite)  do |_ex|
-  #   original_api_host = Rails.configuration.mediaflux["api_host"]
-  #   Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
-  #   reset_mediaflux_root
-  #   Rails.configuration.mediaflux["api_host"] = original_api_host
-  # end
+  config.after(:suite) do |_ex|
+    original_api_host = Rails.configuration.mediaflux["api_host"]
+    Rails.configuration.mediaflux["api_host"] = "0.0.0.0"
+    reset_mediaflux_root
+    Rails.configuration.mediaflux["api_host"] = original_api_host
+  end
 end


### PR DESCRIPTION
Updated code to pass the new HTTP header requested by Arcitecta.

Closes #865

The way to force the HTTP header to be passed to Mediaflux from the TigerData app is the same as documented in PR https://github.com/pulibrary/tiger-data-app/pull/847