### PR TITLE
Added Mediaflux status to the health check page

### DIFF
--- a/app/models/mediaflux_status.rb
+++ b/app/models/mediaflux_status.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 class MediafluxStatus < HealthMonitor::Providers::Base
   def check!
+    # Notice that we check Mediaflux status using our TigerData account
+    # (rather than the "logged in" user since there is not always a logged
+    # in user for the health check)
     domain = Rails.configuration.mediaflux["api_domain"]
     user = Rails.configuration.mediaflux["api_user"]
     password = Rails.configuration.mediaflux["api_password"]

--- a/app/models/mediaflux_status.rb
+++ b/app/models/mediaflux_status.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class MediafluxStatus < HealthMonitor::Providers::Base
+  def check!
+    domain = Rails.configuration.mediaflux["api_domain"]
+    user = Rails.configuration.mediaflux["api_user"]
+    password = Rails.configuration.mediaflux["api_password"]
+    logon_request = Mediaflux::LogonRequest.new(domain:, user:, password:)
+    session_token = logon_request.session_token
+    if logon_request.error?
+      raise logon_request.response_error[:message]
+    else
+      Mediaflux::LogoutRequest.new(session_token:)
+    end
+  end
+end

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
-HealthMonitor.configure do |config|
-  config.cache
+Rails.application.config.after_initialize do
+  HealthMonitor.configure do |config|
+    config.cache
 
-  # Make this health check available at /health
-  config.path = :health
+    # Mediaflux check
+    config.add_custom_provider(MediafluxStatus)
 
-  config.error_callback = proc do |e|
-    Rails.logger.error "Health check failed with: #{e.message}"
-    Honeybadger.notify(e)
+    # Make this health check available at /health
+    config.path = :health
+
+    config.error_callback = proc do |e|
+      Rails.logger.error "Health check failed with: #{e.message}"
+      Honeybadger.notify(e)
+    end
   end
 end

--- a/spec/models/mediaflux_status_spec.rb
+++ b/spec/models/mediaflux_status_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe MediafluxStatus, type: :model do
+  context "when Mediaflux is up and running" do
+    it "reports status OK" do
+      status = described_class.new
+      expect { status.check! }.not_to raise_error
+    end
+  end
+
+  context "when we cannot connecto Mediaflux" do
+    let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
+    let(:error_node) { "<response><reply><error>something went wrong</error></reply></response>" }
+    before do
+      stub_request(:post, mediaflux_url)
+        .to_return(status: 400, body: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n#{error_node}")
+    end
+
+    it "reports that the status is not OK" do
+      status = described_class.new
+      expect { status.check! }.to raise_error
+    end
+  end
+end

--- a/spec/requests/health_check.rb
+++ b/spec/requests/health_check.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Health Check", type: :request do
+  describe "GET /health" do
+    it "has a health check for Mediaflux" do
+      get "/health"
+      expect(response).to be_successful
+      expect(response.body).to include("MediafluxStatus")
+    end
+  end
+end


### PR DESCRIPTION
Closes #883 

Below is how it looks on the screen for an error and for an OK status:

<img width="848" alt="status-not-ok" src="https://github.com/user-attachments/assets/3f09b318-6fcf-4579-95f8-4d7d09ba8092">

<img width="639" alt="status-ok" src="https://github.com/user-attachments/assets/9e749728-05ba-4a12-9673-237984381912">
