### PR TITLE
Moving development to the dev and qa namspace so they are easier to clean up

### DIFF
--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -22,10 +22,11 @@ production:
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
   shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || '/mnt/nfs/tigerdata' %>
 qa:
-  api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-qa-001/tigerdataNS' %>
+  api_root_to_clean: '/td-qa-001/qa'
+  api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-qa-001/qa/tigerdataNS' %>
   api_root_collection_name: 'tigerdata'
-  api_root_collection_namespace: '/td-qa-001'
-  api_root_collection: <%= ENV["MEDIAFLUX_ROOT_NS"] || 'path=/td-qa-001/tigerdata' %>
+  api_root_collection_namespace: '/td-qa-001/qa'
+  api_root_collection: <%= ENV["MEDIAFLUX_ROOT_NS"] || 'path=/td-qa-001/qa/tigerdata' %>
   api_transport: <%= ENV["MEDIAFLUX_TRANSPORT"] || 'https' %>
   api_host: <%= ENV["MEDIAFLUX_HOST"] %>
   api_port: <%= ENV["MEDIAFLUX_PORT"] || 443 %>
@@ -66,10 +67,11 @@ staging:
   api_password: <%= ENV["MEDIAFLUX_PASSWORD"] %>
   shared_files_location: <%= ENV["SHARED_FILES_MOUNT"] || '/mnt/nfs/tigerdata' %>
 development:
-  api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-demo-001/tigerdataNS' %>
+  api_root_to_clean: '/td-demo-001/dev/'
+  api_root_ns: <%= ENV["MEDIAFLUX_ROOT_NS"] || '/td-demo-001/dev/tigerdataNS' %>
   api_root_collection_name: 'tigerdata'
-  api_root_collection_namespace: '/td-demo-001'
-  api_root_collection: <%= ENV["MEDIAFLUX_ROOT_NS"] || 'path=/td-demo-001/tigerdata' %>
+  api_root_collection_namespace: '/td-demo-001/dev'
+  api_root_collection: <%= ENV["MEDIAFLUX_ROOT_NS"] || 'path=/td-demo-001/dev/tigerdata' %>
   api_transport: <%= ENV["MEDIAFLUX_TRANSPORT"] || 'http' %>
   api_host: <%= ENV["MEDIAFLUX_HOST"] || '0.0.0.0' %>
   api_port: <%= ENV["MEDIAFLUX_PORT"] || '8888' %>

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -6,10 +6,10 @@ namespace :mediaflux do
     login = Mediaflux::LogonRequest.new
     login.resolve
     session_id = login.session_token
-    message = "Deleting everything from mediaflux namespace: #{Mediaflux::Connection.root_namespace}"
+    message = "Deleting everything from mediaflux namespace: #{Rails.configuration.mediaflux[:api_root_to_clean]}"
     puts message
     Rails.logger.warn message
-    Mediaflux::NamespaceDestroyRequest.new(session_token: session_id, namespace: Mediaflux::Connection.root_namespace).destroy
+    Mediaflux::NamespaceDestroyRequest.new(session_token: session_id, namespace: Rails.configuration.mediaflux[:api_root_to_clean]).destroy
     [UserRequest, User, Project].each(&:delete_all)
     # Now load the users for this environment from the registration list
     Rake::Task["load_users:from_registration_list"].execute


### PR DESCRIPTION
Adding another level to td-demo-001 & td-qa-001 so we can clean up the collections and the namespaces in one go without removing the top level namespace

Also changes cleanup rake task to utilize the `api_root_to_clean`

fixes #813