### PR TITLE
Changing affiliation from code to name

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link application.css

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -69,7 +69,6 @@
       <select id="departments" name="departments[]"  aria-label="project department" required value class="form-select" multiple >
         <% Affiliation.all.each do |affiliation| %>
           <% if @project.departments.include?(affiliation[:name]) %>
-          <!-- # in form need default to be what's already selected -->
             <option value=<%= affiliation[:code] %> selected><%= affiliation[:name] %></option>
           <% else %>
             <option value=<%= affiliation[:code] %> ><%= affiliation[:name] %></option>

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -69,6 +69,7 @@
       <select id="departments" name="departments[]"  aria-label="project department" required value class="form-select" multiple >
         <% Affiliation.all.each do |affiliation| %>
           <% if @project.departments.include?(affiliation[:name]) %>
+          <!-- # in form need default to be what's already selected -->
             <option value=<%= affiliation[:code] %> selected><%= affiliation[:name] %></option>
           <% else %>
             <option value=<%= affiliation[:code] %> ><%= affiliation[:name] %></option>

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -68,10 +68,10 @@
     <div>Departments:<br/>
       <select id="departments" name="departments[]"  aria-label="project department" required value class="form-select" multiple >
         <% Affiliation.all.each do |affiliation| %>
-          <% if @project.departments.include?(affiliation[:code]) %>
-            <option selected><%= affiliation[:code] %></option>
+          <% if @project.departments.include?(affiliation[:name]) %>
+            <option selected><%= affiliation[:name] %></option>
           <% else %>
-            <option><%= affiliation[:code] %></option>
+            <option><%= affiliation[:name] %></option>
           <% end %>
         <% end %>
       </select>

--- a/app/views/projects/_edit_form.html.erb
+++ b/app/views/projects/_edit_form.html.erb
@@ -69,9 +69,9 @@
       <select id="departments" name="departments[]"  aria-label="project department" required value class="form-select" multiple >
         <% Affiliation.all.each do |affiliation| %>
           <% if @project.departments.include?(affiliation[:name]) %>
-            <option selected><%= affiliation[:name] %></option>
+            <option value=<%= affiliation[:code] %> selected><%= affiliation[:name] %></option>
           <% else %>
-            <option><%= affiliation[:name] %></option>
+            <option value=<%= affiliation[:code] %> ><%= affiliation[:name] %></option>
           <% end %>
         <% end %>
       </select>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -65,8 +65,8 @@ Project Details:
     <dt>Departments</dt>
     <% if @departments.empty? %>
       <dd><strong class="px-0">None</strong></dd>
-    <% else %>
-      <dd><%= @departments %></dd>
+    <% else %> 
+      <dd><%= Affiliation.all.select{|hash| hash[:code]==@departments}[0][:name]%></dd>
     <% end %>
     <dt>Project Directory</dt>
     <dd><%= @project.project_directory %></dd>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -67,7 +67,7 @@ Project Details:
       <dd><strong class="px-0">None</strong></dd>
     <% else %>
       <dd>
-        <% @project.departments.each do |department_code| %>
+        <% @project.project.metadata_json["departments"].each do |department_code| %>
           <% Affiliation.all.each do |hash| %>
             <% if hash[:code] == department_code %>
             <%= hash[:name] %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -65,8 +65,16 @@ Project Details:
     <dt>Departments</dt>
     <% if @departments.empty? %>
       <dd><strong class="px-0">None</strong></dd>
-    <% else %> 
-      <dd><%= Affiliation.all.select{|hash| hash[:code]==@departments}[0][:name]%></dd>
+    <% else %>
+      <dd>
+        <% @project.departments.each do |department_code| %>
+          <% Affiliation.all.each do |hash| %>
+            <% if hash[:code] == department_code %>
+            <%= hash[:name] %>
+            <% end %>      
+          <% end %>
+        <% end %>
+      </dd>
     <% end %>
     <dt>Project Directory</dt>
     <dd><%= @project.project_directory %></dd>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe ProjectsController do
+RSpec.describe ProjectsController, type: ["controller", "feature"] do
   let(:project) { FactoryBot.create :project }
   describe "#show" do
     it "renders an error when requesting json" do
@@ -88,6 +88,34 @@ RSpec.describe ProjectsController do
         }
         project = Project.last
         expect(project.provenance_events.count).to eq 2
+      end
+      it "shows affiliation name/title instead of code on project show page" do
+        get :show, params: { id: Project.last.id }
+        save_and_open_page
+        # visit("/projects/" + project.id.to_s)
+        expect(page).to have_content("Astrophysical Sciences")
+                    .or(have_content("High Performance Computing"))
+          .or(have_content("Research Data and Scholarly Services"))
+          .or(have_content("Princeton Research Data Service"))
+          .or(have_content("Princeton Plasma Physics Laboratory"))
+      end
+      it "shows affiliation code as being saved to the project" do
+        get :show, params: { id: project.id }
+        puts(response.body)
+        body = JSON.parse(response.body)
+        expect(body).to include("23100")
+                    .or(include("HPC"))
+          .or(include("RDSS"))
+          .or(include("PRDS"))
+          .or(include("PPPL"))
+      end
+      it "shows affiliation name/title instead of code on project edit page" do
+        visit("/projects/" + project.id.to_s + "/edit")
+        expect(page).to have_content("Astrophysical Sciences")
+                    .or(have_content("High Performance Computing"))
+          .or(have_content("Research Data and Scholarly Services"))
+          .or(have_content("Princeton Research Data Service"))
+          .or(have_content("Princeton Plasma Physics Laboratory"))
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -106,19 +106,16 @@ RSpec.describe ProjectsController, type: ["controller", "feature"] do
     let(:current_user) { FactoryBot.create(:user, uid: "pul123") }
 
     before do
-      FactoryBot.create(:project, data_sponsor: current_user.uid, data_manager: other_user.uid, title: "project 111")
-      FactoryBot.create(:project, data_sponsor: other_user.uid, data_manager: current_user.uid, title: "project 222")
-      FactoryBot.create(:project, data_sponsor: other_user.uid, data_manager: other_user.uid, data_user_read_only: [current_user.uid], title: "project 333")
-      FactoryBot.create(:project, data_sponsor: other_user.uid, data_manager: other_user.uid, title: "project 444")
+      FactoryBot.create(:project, data_sponsor: current_user.uid, data_manager: current_user.uid, title: "project 111")
     end
 
-    it "works" do
+    it "shows affiliation name/title instead of code on project show page" do
       sign_in current_user
-      visit("/")
-      #      project = Project.last
+
+      project = Project.last
       # visit the show page
-      # get :show, params: { id: project.id }
-      # visit("/projects/" + project.id.to_s)
+      get :show, params: { id: project.id }
+      visit("/projects/" + project.id.to_s)
       expect(page).to have_content("Astrophysical Sciences")
                   .or(have_content("High Performance Computing"))
         .or(have_content("Research Data and Scholarly Services"))

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ProjectsController, type: ["controller", "feature"] do
       it "renders the project metadata as xml" do
         project = FactoryBot.create :project, project_id: "abc-123"
         get :show, params: { id: project.id, format: :xml }
-        save_and_open_page
         expect(response.content_type).to eq("application/xml; charset=utf-8")
         expect(response.body).to eq(
         "<?xml version=\"1.0\"?>\n" \

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
       page.find("body").click
       click_on "btn-add-rw-user"
       # select a department
-      select "RDSS", from: "departments"
+      select "Research Data and Scholarly Services", from: "departments"
       fill_in "project_directory", with: "test_project"
       fill_in "title", with: "My test project"
       expect(page).to have_content("Project Directory: /td-test-001/")
@@ -346,7 +346,7 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
         # Without removing the focus from the form field, the "change" event is not propagated for the DOM
         page.find("body").click
         click_on "btn-add-rw-user"
-        select "RDSS", from: "departments"
+        select "Research Data and Scholarly Services", from: "departments"
         fill_in "project_directory", with: FFaker::Name.name.tr(" ", "_")
         fill_in "title", with: "My test project"
         expect(page).to have_content("Project Directory: /td-test-001/")
@@ -399,7 +399,7 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
         # Without removing the focus from the form field, the "change" event is not propagated for the DOM
         page.find("body").click
         click_on "btn-add-rw-user"
-        select "RDSS", from: "departments"
+        select "Research Data and Scholarly Services", from: "departments"
         fill_in "project_directory", with: FFaker::Name.name.tr(" ", "_")
         fill_in "title", with: "My test project"
         expect(page).to have_content("Project Directory: /td-test-001/")


### PR DESCRIPTION
Resolves #931 by showing the affiliation name/title on the project show page and in the project form selection menu, but keeps these changes only in the UI, that is, the associated data in the database records the affiliation code, not name/title.