### PR TITLE
New ProjectXmlPresenter class

### DIFF
--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -46,6 +46,20 @@ class ProjectXmlPresenter
       new_node
     end
 
+    def description_node
+      # <description xml:lang="en"
+      # inherited="false"
+      # discoverable="true"
+      # trackingLevel="ResourceRecord">This is just an example description.</description>
+      new_node = @document.create_element("description")
+      new_node["inherited"] = "false"
+      new_node["discoverable"] = "true"
+      new_node["trackingLevel"] = "ResourceRecord"
+      new_node.content = description
+
+      new_node
+    end
+
     def root_node
       # An example root node:
       # <resource resourceClass="Project"
@@ -61,6 +75,7 @@ class ProjectXmlPresenter
                        root["resourceIDType"] = "DOI"
 
                        root.add_child(title_node)
+                       root.add_child(description_node)
                        root
                      end
     end

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -9,4 +9,33 @@ class ProjectXmlPresenter
     @project = project
     @project_metadata = @project.metadata_model
   end
+
+  def document
+    @document ||= build_xml_document
+  end
+  alias to_xml document
+
+  private
+
+    def xml_version
+      "1.0"
+    end
+
+    def xml_document_args
+      [
+        xml_version
+      ]
+    end
+
+    def build_xml_document
+      Nokogiri::XML::Document.new(*xml_document_args)
+    end
+
+    def root_node
+      # <resource resourceClass="Project" resourceID="10.34770/az09-0003" resourceIDType="DOI">
+      @root_node ||= begin
+                       name = "resource"
+                       document.create_element(name)
+                     end
+    end
 end

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class ProjectXmlPresenter
+  delegate "id", "in_mediaflux?", "mediaflux_id", "pending?", "status", "title", to: :project
+  delegate "description", "project_id", "storage_performance_expectations", "project_purpose", to: :project_metadata
+
+  attr_reader :project, :project_metadata
+
+  def initialize(project)
+    @project = project
+    @project_metadata = @project.metadata_model
+  end
+end

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -31,19 +31,36 @@ class ProjectXmlPresenter
       Nokogiri::XML::Document.new(*xml_document_args)
     end
 
+    def title_node
+      # <title xml:lang="en"
+      # inherited="false"
+      # discoverable="true"
+      # trackingLevel="ResourceRecord">Test Item 1</title>
+      new_node = @document.create_element("title")
+      # TODO: Determine how Ruby models might affect these attributes
+      new_node["inherited"] = "false"
+      new_node["discoverable"] = "true"
+      new_node["trackingLevel"] = "ResourceRecord"
+      new_node.content = title
+
+      new_node
+    end
+
     def root_node
       # An example root node:
       # <resource resourceClass="Project"
       # resourceID="10.34770/az09-0003"
       # resourceIDType="DOI">
       @root_node ||= begin
-                       new_document = build_xml_document
+                       @document = build_xml_document
                        root_name = "resource"
-                       root = new_document.create_element(root_name)
-                       new_document.root = root
+                       root = @document.create_element(root_name)
+                       @document.root = root
                        root["resourceClass"] = "Project"
                        root["resourceID"] = project_id
                        root["resourceIDType"] = "DOI"
+
+                       root.add_child(title_node)
                        root
                      end
     end

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -11,7 +11,7 @@ class ProjectXmlPresenter
   end
 
   def document
-    @document ||= build_xml_document
+    @document ||= root_node.document
   end
   alias to_xml document
 
@@ -32,10 +32,19 @@ class ProjectXmlPresenter
     end
 
     def root_node
-      # <resource resourceClass="Project" resourceID="10.34770/az09-0003" resourceIDType="DOI">
+      # An example root node:
+      # <resource resourceClass="Project"
+      # resourceID="10.34770/az09-0003"
+      # resourceIDType="DOI">
       @root_node ||= begin
-                       name = "resource"
-                       document.create_element(name)
+                       new_document = build_xml_document
+                       root_name = "resource"
+                       root = new_document.create_element(root_name)
+                       new_document.root = root
+                       root["resourceClass"] = "Project"
+                       root["resourceID"] = project_id
+                       root["resourceIDType"] = "DOI"
+                       root
                      end
     end
 end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -26,5 +26,17 @@ RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
       expect(presenter.to_xml.root["resourceID"]).to eq(project.metadata_model.project_id)
       expect(presenter.to_xml.root["resourceIDType"]).to eq("DOI")
     end
+
+    describe "<title>" do
+      let(:title_node) { presenter.to_xml.root.at_xpath("title") }
+
+      it "builds a <title> element containing the title of the project" do
+        expect(title_node).to be_a(Nokogiri::XML::Element)
+        expect(title_node.name).to eq("title")
+        expect(title_node["inherited"]).to eq("false")
+        expect(title_node["discoverable"]).to eq("true")
+        expect(title_node["trackingLevel"]).to eq("ResourceRecord")
+      end
+    end
   end
 end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -29,13 +29,24 @@ RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
 
     describe "<title>" do
       let(:title_node) { presenter.to_xml.root.at_xpath("title") }
-
       it "builds a <title> element containing the title of the project" do
         expect(title_node).to be_a(Nokogiri::XML::Element)
         expect(title_node.name).to eq("title")
         expect(title_node["inherited"]).to eq("false")
         expect(title_node["discoverable"]).to eq("true")
         expect(title_node["trackingLevel"]).to eq("ResourceRecord")
+      end
+    end
+
+    describe "<description>" do
+      let(:description_node) { presenter.to_xml.root.at_xpath("description") }
+
+      it "builds a <description> element containing the description of the project" do
+        expect(description_node).to be_a(Nokogiri::XML::Element)
+        expect(description_node.name).to eq("description")
+        expect(description_node["inherited"]).to eq("false")
+        expect(description_node["discoverable"]).to eq("true")
+        expect(description_node["trackingLevel"]).to eq("ResourceRecord")
       end
     end
   end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
-  let(:project) { FactoryBot.create :project }
+  let(:project) { FactoryBot.create :project_with_doi }
   subject(:presenter) { described_class.new(project) }
 
   it "can be instantiated" do
@@ -17,6 +17,14 @@ RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
   describe "#to_xml" do
     it "generates a XML Document" do
       expect(presenter.to_xml).to be_a(Nokogiri::XML::Document)
+    end
+
+    it "ensures that the root node is a <resource> element with the required attributes" do
+      expect(presenter.to_xml.root).to be_a(Nokogiri::XML::Element)
+      expect(presenter.to_xml.root.name).to eq("resource")
+      expect(presenter.to_xml.root["resourceClass"]).to eq("Project")
+      expect(presenter.to_xml.root["resourceID"]).to eq(project.metadata_model.project_id)
+      expect(presenter.to_xml.root["resourceIDType"]).to eq("DOI")
     end
   end
 end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
+  let(:project) { FactoryBot.create :project }
+  subject(:presenter) { described_class.new(project) }
+
+  it "can be instantiated" do
+    expect(presenter).to be_instance_of(described_class)
+  end
+end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -10,10 +10,13 @@ RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
   end
 
   context "rails XML payload" do
-    it 'has an xml payload' do
-      
+    it "has an xml payload" do
     end
-    
   end
-  
+
+  describe "#to_xml" do
+    it "generates a XML Document" do
+      expect(presenter.to_xml).to be_a(Nokogiri::XML::Document)
+    end
+  end
 end

--- a/spec/models/project_xml_presenter_spec.rb
+++ b/spec/models/project_xml_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe ProjectXmlPresenter, type: :model, connect_to_mediaflux: false do
   it "can be instantiated" do
     expect(presenter).to be_instance_of(described_class)
   end
+
+  context "rails XML payload" do
+    it 'has an xml payload' do
+      
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
Ref #1413 

Goals:
* Make a class called `ProjectXmlPresenter`
* It takes a `Project` as input: `ProjectXmlPresenter.new(@project)`
* need to respond to the `to_xml` message and return an XML document that follows the v0.8 schema as much as possible 