### PR TITLE
Makes wizard controllers unavailable if the flipper is not on

### DIFF
--- a/app/controllers/request_wizards_controller.rb
+++ b/app/controllers/request_wizards_controller.rb
@@ -3,6 +3,8 @@ class RequestWizardsController < ApplicationController
   before_action :set_request_model, only: %i[save]
   before_action :set_or_create_request_model, only: %i[show]
 
+  before_action :check_flipper
+
   attr_reader :request_model
 
   # GET /request_wizards/1
@@ -60,5 +62,9 @@ class RequestWizardsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def request_params
       params.fetch(:request, {}).permit(:request_title, :project_title)
+    end
+
+    def check_flipper
+      return head :forbidden unless Flipflop.new_project_request_wizard?
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,20 +69,20 @@ Rails.application.routes.draw do
   get "new-project/storage-access/:request_id", to: "new_project_wizard/storage_and_access#show", as: :new_project_storage_and_access
   put "new-project/storage-access/:request_id/save", to: "new_project_wizard/storage_and_access#save", as: :new_project_storage_and_access_save
 
-  get "new-project/additional-information-grants-funding/:request_id", to: "new_project_wizard/additional_information_grants_and_funding#show",
-                                                                       as: :new_project_additional_information_grants_and_funding
-  put "new-project/additional-information-grants-funding/:request_id/save", to: "new_project_wizard/additional_information_grants_and_funding#save",
-                                                                            as: :new_project_additional_information_grants_and_funding_save
+  get "new-project/additional-info-grants-funding/:request_id", to: "new_project_wizard/additional_information_grants_and_funding#show",
+                                                                as: :new_project_additional_information_grants_and_funding
+  put "new-project/additional-info-grants-funding/:request_id/save", to: "new_project_wizard/additional_information_grants_and_funding#save",
+                                                                     as: :new_project_additional_information_grants_and_funding_save
 
-  get "new-project/additional-information-project-permissions/:request_id", to: "new_project_wizard/additional_information_project_permissions#show",
-                                                                            as: :new_project_additional_information_project_permissions
-  put "new-project/additional-information-project-permissions/:request_id/save", to: "new_project_wizard/additional_information_project_permissions#save",
-                                                                                 as: :new_project_additional_information_project_permissions_save
+  get "new-project/additional-info-project-permissions/:request_id", to: "new_project_wizard/additional_information_project_permissions#show",
+                                                                     as: :new_project_additional_information_project_permissions
+  put "new-project/additional-info-project-permissions/:request_id/save", to: "new_project_wizard/additional_information_project_permissions#save",
+                                                                          as: :new_project_additional_information_project_permissions_save
 
-  get "new-project/additional-information-related-resources/:request_id", to: "new_project_wizard/additional_information_related_resources#show",
-                                                                          as: :new_project_additional_information_related_resources
-  put "new-project/additional-information-related-resources/:request_id/save", to: "new_project_wizard/additional_information_related_resources#save",
-                                                                               as: :new_project_additional_information_related_resources_save
+  get "new-project/additional-info-related-resources/:request_id", to: "new_project_wizard/additional_information_related_resources#show",
+                                                                   as: :new_project_additional_information_related_resources
+  put "new-project/additional-info-related-resources/:request_id/save", to: "new_project_wizard/additional_information_related_resources#save",
+                                                                        as: :new_project_additional_information_related_resources_save
 
   get "new-project/review-submit/:request_id", to: "new_project_wizard/review_and_submit#show", as: :new_project_review_and_submit
   put "new-project/review-submit/:request_id/save", to: "new_project_wizard/review_and_submit#save", as: :new_project_review_and_submit_save

--- a/docs/request_wizard.md
+++ b/docs/request_wizard.md
@@ -16,7 +16,7 @@ The step controllers need to implement the methods to render or redirect the vie
 
 ## Routes
 
-The routes should include a top level path item for the wizard and then a path item for the step. ( new-project/project-information). Routes are needed for the show and save of each step.
+The routes should include a top level path item for the wizard and then a path item for the step. ( new-project/project-info). Routes are needed for the show and save of each step.
 
 ## Adding a new step
 

--- a/spec/requests/new_project_wizard/additional_information_grants_and_funding_spec.rb
+++ b/spec/requests/new_project_wizard/additional_information_grants_and_funding_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "new-project/additional-information-grants-funding", type: :request do
+RSpec.describe "new-project/additional-info-grants-funding", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_additional_information_grants_and_funding_url(1)

--- a/spec/requests/new_project_wizard/additional_information_project_permissions_spec.rb
+++ b/spec/requests/new_project_wizard/additional_information_project_permissions_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "new-project/additional-information-project-permissions", type: :request do
+RSpec.describe "new-project/additional-info-project-permissions", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_additional_information_project_permissions_url(1)

--- a/spec/requests/new_project_wizard/additional_information_related_resources_spec.rb
+++ b/spec/requests/new_project_wizard/additional_information_related_resources_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "new-project/additional-information-related-resources", type: :request do
+RSpec.describe "new-project/additional-info-related-resources", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_additional_information_related_resources_url(1)

--- a/spec/requests/new_project_wizard/project_info_categories_spec.rb
+++ b/spec/requests/new_project_wizard/project_info_categories_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/project-info-categories", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_project_info_categories_url(1)

--- a/spec/requests/new_project_wizard/project_info_dates_spec.rb
+++ b/spec/requests/new_project_wizard/project_info_dates_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/project-info-dates", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_project_info_dates_url(1)

--- a/spec/requests/new_project_wizard/project_info_spec.rb
+++ b/spec/requests/new_project_wizard/project_info_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "/new-project/project-info", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_project_info_url

--- a/spec/requests/new_project_wizard/project_type_spec.rb
+++ b/spec/requests/new_project_wizard/project_type_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/project-type", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_project_type_url(1)

--- a/spec/requests/new_project_wizard/review_and_submit_spec.rb
+++ b/spec/requests/new_project_wizard/review_and_submit_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/review-submit", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_review_and_submit_url(1)

--- a/spec/requests/new_project_wizard/roles_and_people_spec.rb
+++ b/spec/requests/new_project_wizard/roles_and_people_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/roles-people", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_roles_and_people_url(1)

--- a/spec/requests/new_project_wizard/storage_and_access_spec.rb
+++ b/spec/requests/new_project_wizard/storage_and_access_spec.rb
@@ -2,6 +2,11 @@
 require "rails_helper"
 
 RSpec.describe "new-project/storage-access", type: :request do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_project_request_wizard, true)
+  end
+
   describe "GET" do
     it "redirects the client to the sign in path" do
       get new_project_storage_and_access_url(1)

--- a/spec/routing/new_project_wizard/additional_information_grants_and_funding_routing_spec.rb
+++ b/spec/routing/new_project_wizard/additional_information_grants_and_funding_routing_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 RSpec.describe NewProjectWizard::AdditionalInformationGrantsAndFundingController, type: :routing do
   describe "routing" do
     it "routes to #show" do
-      expect(get: "/new-project/additional-information-grants-funding/1").to route_to("new_project_wizard/additional_information_grants_and_funding#show", "request_id" => "1")
+      expect(get: "/new-project/additional-info-grants-funding/1").to route_to("new_project_wizard/additional_information_grants_and_funding#show", "request_id" => "1")
     end
 
     it "routes to #save" do
-      expect(put: "/new-project/additional-information-grants-funding/1/save").to route_to("new_project_wizard/additional_information_grants_and_funding#save", "request_id" => "1")
+      expect(put: "/new-project/additional-info-grants-funding/1/save").to route_to("new_project_wizard/additional_information_grants_and_funding#save", "request_id" => "1")
     end
   end
 end

--- a/spec/routing/new_project_wizard/additional_information_project_permissions_routing_spec.rb
+++ b/spec/routing/new_project_wizard/additional_information_project_permissions_routing_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 RSpec.describe NewProjectWizard::AdditionalInformationProjectPermissionsController, type: :routing do
   describe "routing" do
     it "routes to #show" do
-      expect(get: "/new-project/additional-information-project-permissions/1").to route_to("new_project_wizard/additional_information_project_permissions#show", "request_id" => "1")
+      expect(get: "/new-project/additional-info-project-permissions/1").to route_to("new_project_wizard/additional_information_project_permissions#show", "request_id" => "1")
     end
 
     it "routes to #save" do
-      expect(put: "/new-project/additional-information-project-permissions/1/save").to route_to("new_project_wizard/additional_information_project_permissions#save", "request_id" => "1")
+      expect(put: "/new-project/additional-info-project-permissions/1/save").to route_to("new_project_wizard/additional_information_project_permissions#save", "request_id" => "1")
     end
   end
 end

--- a/spec/routing/new_project_wizard/additional_information_related_resources_routing_spec.rb
+++ b/spec/routing/new_project_wizard/additional_information_related_resources_routing_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 RSpec.describe NewProjectWizard::AdditionalInformationRelatedResourcesController, type: :routing do
   describe "routing" do
     it "routes to #show" do
-      expect(get: "/new-project/additional-information-project-permissions/1").to route_to("new_project_wizard/additional_information_project_permissions#show", "request_id" => "1")
+      expect(get: "/new-project/additional-info-project-permissions/1").to route_to("new_project_wizard/additional_information_project_permissions#show", "request_id" => "1")
     end
 
     it "routes to #save" do
-      expect(put: "/new-project/additional-information-project-permissions/1/save").to route_to("new_project_wizard/additional_information_project_permissions#save", "request_id" => "1")
+      expect(put: "/new-project/additional-info-project-permissions/1/save").to route_to("new_project_wizard/additional_information_project_permissions#save", "request_id" => "1")
     end
   end
 end

--- a/spec/system/new_project_request_wizard_spec.rb
+++ b/spec/system/new_project_request_wizard_spec.rb
@@ -17,7 +17,7 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
 
   context "authenticated user" do
     let(:current_user) { FactoryBot.create(:user, uid: "pul123") }
-    it "walks through the wizard" do
+    it "walks through the wizard if the feature is enabled" do
       test_strategy = Flipflop::FeatureSet.current.test!
       test_strategy.switch!(:new_project_request_wizard, true)
       sign_in current_user
@@ -60,6 +60,35 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
       expect(page).to have_content "Project Information: Categories"
       click_on "Back"
       expect(page).to have_content "Project Information: Basic"
+    end
+
+    it "walks through the wizard if the feature is enabled" do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:new_project_request_wizard, false)
+      request = Request.create
+      sign_in current_user
+      visit "/"
+      expect(page).not_to have_content("New Project Request")
+      visit "/new-project/project-info/#{request.id}"
+      expect(page).not_to have_content "Project Information: Basic"
+      visit "/new-project/project-info-categories/#{request.id}"
+      expect(page).not_to have_content "Project Information: Categories"
+      visit "/new-project/project-info-dates/#{request.id}"
+      expect(page).not_to have_content "Project Information: Dates"
+      visit "/new-project/roles-people/#{request.id}"
+      expect(page).not_to have_content "Roles and People"
+      visit "/new-project/project-type/#{request.id}"
+      expect(page).not_to have_content "Project Type"
+      visit "/new-project/storage-access/#{request.id}"
+      expect(page).not_to have_content "Storage and Access"
+      visit "/new-project/additional-info-grants-funding/#{request.id}"
+      expect(page).not_to have_content "Additional Information: Grants and Funding"
+      visit "/new-project/additional-info-project-permissions/#{request.id}"
+      expect(page).not_to have_content "Additional Information: Project Permissions"
+      visit "/new-project/additional-info-related-resources/#{request.id}"
+      expect(page).not_to have_content "Additional Information: Related Resources"
+      visit "/new-project/review-submit/#{request.id}"
+      expect(page).not_to have_content "Review and Submit"
     end
   end
 end


### PR DESCRIPTION
Also renames `addition-information` url to `additional-info` to match the `project-info` url for consistency
 
fixes #1437