### PR TITLE
Fixed test that was using old root Mediaflux namespace

### DIFF
--- a/spec/models/mediaflux/namespace_exist_request_spec.rb
+++ b/spec/models/mediaflux/namespace_exist_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Mediaflux::NamespaceExistRequest, type: :model, connect_to_mediaf
       subject = described_class.new(session_token: session_token, namespace: namespace_non_existing)
       expect(subject.exist?).to be false
 
-      subject = described_class.new(session_token: session_token, namespace: namespace_root )
+      subject = described_class.new(session_token: session_token, namespace: namespace_root)
       expect(subject.exist?).to be true
     end
   end


### PR DESCRIPTION
Adjust test to not use `td-test-001` as the root namespace when running rspec and use the new `/princeton` namespace that comes in the Docker container with Mediaflux.

Closes #1625 