### PR TITLE
Moving form-field css outside of the scrollable frame

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -110,303 +110,6 @@
             line-height: 1.5rem; /* 150% */
           }
         }
-        .form-field {
-          display: flex;
-          align-items: flex-start;
-          gap: 1.25rem;
-          align-self: stretch;
-
-          .field-info {
-            display: flex;
-            width: 11.4375rem;
-            flex-direction: column;
-            align-items: flex-start;
-
-            .field-label {
-              color: $gray-100;
-
-              /* Body Bold */
-              font-family: $libre-franklin;
-              font-size: 1.125rem;
-              font-style: normal;
-              font-weight: 600;
-              line-height: 1.6875rem; /* 150% */
-            }
-
-            .field-sub-label {
-              width: 8.375rem;
-              color: $gray-60;
-
-              /* Body XS */
-              font-family: $libre-franklin;
-              font-size: 0.875rem;
-              font-style: normal;
-              font-weight: 400;
-              line-height: 1.3125rem; /* 150% */
-            }
-          }
-
-          .input-label {
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-
-            .label {
-              color: $gray-60;
-
-              /* Body XS Bold */
-              font-family: $libre-franklin;
-              font-size: 0.875rem;
-              font-style: normal;
-              font-weight: 600;
-              line-height: 1.3125rem; /* 150% */
-            }
-            .info {
-              width: 1.5rem;
-              height: 1.5rem;
-              aspect-ratio: 1/1;
-              background: url("info.svg") no-repeat;
-            }
-
-            .info {
-              position: relative; /* Required for the pseudo-element to be positioned relative to the div */
-              display: inline-block; /* Or block, depending on your layout */
-            }
-
-            .info::after {
-              content: attr(data-tooltip); /* Pulls the text from the data-tooltip attribute */
-              visibility: hidden;
-              position: relative;
-              bottom: 125%; /* Positions the tooltip above the div */
-              transform: translateX(-50%);
-
-              /* Styling for the tooltip box */
-              background-color: #333;
-              color: #fff;
-              font-size: 12px;
-              padding: 8px 12px;
-              border-radius: 4px;
-              white-space: nowrap;
-              text-overflow: ellipsis;
-              overflow: hidden;
-              @supports (-webkit-line-clamp: 4) {
-                overflow: hidden;
-                width: 20rem;
-                text-overflow: ellipsis;
-                white-space: initial;
-                display: -webkit-box;
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 4;
-              }
-              z-index: 1; /* Ensures the tooltip is on top of other content */
-            }
-
-            .info:hover::after {
-              visibility: visible;
-            }
-          }
-
-          .input-frame {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 0.5rem;
-            flex: 1 0 0;
-            .text-input {
-              display: flex;
-              flex-direction: column;
-              align-items: flex-start;
-              gap: 0.25rem;
-              .horizontal-frame {
-                display: flex;
-                align-items: flex-start;
-                gap: 0.25rem;
-                align-self: stretch;
-                .vertical-frame {
-                  display: flex;
-                  flex-direction: column;
-                  align-items: flex-start;
-                  gap: 0.25rem;
-                  flex: 1 0 0;
-                  .form-input {
-                    display: flex;
-                    width: 36.875rem;
-                    flex-direction: column;
-                    align-items: flex-start;
-                    gap: 0.25rem;
-                  }
-                  .char-limit {
-                    display: flex;
-                    justify-content: flex-end;
-                    align-items: center;
-                    align-self: stretch;
-                    .char-limit-text {
-                      color: $gray-60;
-
-                      /* Body XXS */
-                      font-family: $libre-franklin;
-                      font-size: 0.75rem;
-                      font-style: normal;
-                      font-weight: 400;
-                      line-height: 1.125rem; /* 150% */
-                    }
-                  }
-                  .error-and-count {
-                    .input-error {
-                      flex-basis: 80%;
-                    }
-                  }
-                }
-              }
-            }
-            .input-error {
-              color: var(--Secondary-Red-Dark, #b00002);
-
-              /* Body XXS */
-              font-family: "Libre Franklin";
-              font-size: 0.75rem;
-              font-style: normal;
-              font-weight: 400;
-              line-height: 1.125rem; /* 150% */
-            }
-            .number-input {
-              display: flex;
-              flex-direction: column;
-              align-items: flex-start;
-              gap: 0.25rem;
-              flex: 1 0 0;
-            }
-            .project-directory {
-              display: flex;
-              width: 38.625rem;
-              align-items: center;
-              gap: 0.5rem;
-              .parent-folder {
-                display: flex;
-                width: 15rem;
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 0.25rem;
-                flex-shrink: 0;
-              }
-              .project-folder {
-                display: flex;
-                width: 23.125rem;
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 0.25rem;
-                flex-shrink: 0;
-              }
-            }
-          }
-
-          .storage-frame {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 0.75rem;
-            flex: 1 0 0;
-
-            .options-frame {
-              display: flex;
-              flex-direction: column;
-              align-items: flex-start;
-              gap: 0.5rem;
-              align-self: stretch;
-
-              .quota-select {
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-                align-self: stretch;
-              }
-
-              .quota-option {
-                display: flex;
-                padding: 0.5rem 0.75rem;
-                justify-content: center;
-                align-items: center;
-                gap: 0.625rem;
-                flex: 1 0 0;
-              }
-            }
-
-            .quota-select input[type="radio"] {
-              opacity: 0;
-              position: fixed;
-              width: 0;
-            }
-            .quota-select label {
-              border-radius: 0.5rem;
-              border: 1px solid $gray-20;
-              background: $white;
-              display: flex;
-              padding: 0.5rem 0.75rem;
-              justify-content: center;
-              align-items: center;
-              gap: 0.625rem;
-              flex: 1 0 0;
-              color: $gray-100;
-
-              /* Body S */
-              font-family: $libre-franklin;
-              font-size: 1rem;
-              font-style: normal;
-              font-weight: 400;
-              line-height: 1.5rem; /* 150% */
-            }
-
-            .quota-select input[type="radio"]:checked + label {
-              border-radius: 0.5rem;
-              border: 1px solid $princeton-orange;
-              background: $white;
-            }
-
-            .hidden-div {
-              display: flex;
-              align-items: center;
-              gap: 2.5rem;
-              align-self: stretch;
-
-              .custom-quota {
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-                flex: 1 0 0;
-                width: 100%;
-                padding: 1rem;
-              }
-            }
-          }
-
-          .selected-items {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 0.25rem;
-            list-style-type: none;
-            padding-left: 0;
-            width: 100%;
-
-            .selected-item {
-              display: flex;
-              height: 2.25rem;
-              padding: 0.25rem 0.75rem;
-              align-items: center;
-              gap: 1.25rem;
-              border-radius: 0.25rem;
-              background: $gray-10;
-              width: 100%;
-            }
-          }
-          .remove-item {
-            width: 1rem;
-            height: 1rem;
-            flex-shrink: 0;
-            cursor: pointer;
-            background: url("remove.svg") no-repeat;
-          }
-        }
 
         .form-frame {
           display: flex;
@@ -447,6 +150,304 @@
             height: 0.0625rem;
             background: $gray-10;
           }
+        }
+      }
+
+      .form-field {
+        display: flex;
+        align-items: flex-start;
+        gap: 1.25rem;
+        align-self: stretch;
+
+        .field-info {
+          display: flex;
+          width: 11.4375rem;
+          flex-direction: column;
+          align-items: flex-start;
+
+          .field-label {
+            color: $gray-100;
+
+            /* Body Bold */
+            font-family: $libre-franklin;
+            font-size: 1.125rem;
+            font-style: normal;
+            font-weight: 600;
+            line-height: 1.6875rem; /* 150% */
+          }
+
+          .field-sub-label {
+            width: 8.375rem;
+            color: $gray-60;
+
+            /* Body XS */
+            font-family: $libre-franklin;
+            font-size: 0.875rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 1.3125rem; /* 150% */
+          }
+        }
+
+        .input-label {
+          display: flex;
+          align-items: center;
+          gap: 0.25rem;
+
+          .label {
+            color: $gray-60;
+
+            /* Body XS Bold */
+            font-family: $libre-franklin;
+            font-size: 0.875rem;
+            font-style: normal;
+            font-weight: 600;
+            line-height: 1.3125rem; /* 150% */
+          }
+          .info {
+            width: 1.5rem;
+            height: 1.5rem;
+            aspect-ratio: 1/1;
+            background: url("info.svg") no-repeat;
+          }
+
+          .info {
+            position: relative; /* Required for the pseudo-element to be positioned relative to the div */
+            display: inline-block; /* Or block, depending on your layout */
+          }
+
+          .info::after {
+            content: attr(data-tooltip); /* Pulls the text from the data-tooltip attribute */
+            visibility: hidden;
+            position: relative;
+            bottom: 125%; /* Positions the tooltip above the div */
+            transform: translateX(-50%);
+
+            /* Styling for the tooltip box */
+            background-color: #333;
+            color: #fff;
+            font-size: 12px;
+            padding: 8px 12px;
+            border-radius: 4px;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            @supports (-webkit-line-clamp: 4) {
+              overflow: hidden;
+              width: 20rem;
+              text-overflow: ellipsis;
+              white-space: initial;
+              display: -webkit-box;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 4;
+            }
+            z-index: 1; /* Ensures the tooltip is on top of other content */
+          }
+
+          .info:hover::after {
+            visibility: visible;
+          }
+        }
+
+        .input-frame {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.5rem;
+          flex: 1 0 0;
+          .text-input {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.25rem;
+            .horizontal-frame {
+              display: flex;
+              align-items: flex-start;
+              gap: 0.25rem;
+              align-self: stretch;
+              .vertical-frame {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.25rem;
+                flex: 1 0 0;
+                .form-input {
+                  display: flex;
+                  width: 36.875rem;
+                  flex-direction: column;
+                  align-items: flex-start;
+                  gap: 0.25rem;
+                }
+                .char-limit {
+                  display: flex;
+                  justify-content: flex-end;
+                  align-items: center;
+                  align-self: stretch;
+                  .char-limit-text {
+                    color: $gray-60;
+
+                    /* Body XXS */
+                    font-family: $libre-franklin;
+                    font-size: 0.75rem;
+                    font-style: normal;
+                    font-weight: 400;
+                    line-height: 1.125rem; /* 150% */
+                  }
+                }
+                .error-and-count {
+                  .input-error {
+                    flex-basis: 80%;
+                  }
+                }
+              }
+            }
+          }
+          .input-error {
+            color: var(--Secondary-Red-Dark, #b00002);
+
+            /* Body XXS */
+            font-family: "Libre Franklin";
+            font-size: 0.75rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 1.125rem; /* 150% */
+          }
+          .number-input {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.25rem;
+            flex: 1 0 0;
+          }
+          .project-directory {
+            display: flex;
+            width: 38.625rem;
+            align-items: center;
+            gap: 0.5rem;
+            .parent-folder {
+              display: flex;
+              width: 15rem;
+              flex-direction: column;
+              align-items: flex-start;
+              gap: 0.25rem;
+              flex-shrink: 0;
+            }
+            .project-folder {
+              display: flex;
+              width: 23.125rem;
+              flex-direction: column;
+              align-items: flex-start;
+              gap: 0.25rem;
+              flex-shrink: 0;
+            }
+          }
+        }
+
+        .storage-frame {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.75rem;
+          flex: 1 0 0;
+
+          .options-frame {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.5rem;
+            align-self: stretch;
+
+            .quota-select {
+              display: flex;
+              align-items: center;
+              gap: 0.5rem;
+              align-self: stretch;
+            }
+
+            .quota-option {
+              display: flex;
+              padding: 0.5rem 0.75rem;
+              justify-content: center;
+              align-items: center;
+              gap: 0.625rem;
+              flex: 1 0 0;
+            }
+          }
+
+          .quota-select input[type="radio"] {
+            opacity: 0;
+            position: fixed;
+            width: 0;
+          }
+          .quota-select label {
+            border-radius: 0.5rem;
+            border: 1px solid $gray-20;
+            background: $white;
+            display: flex;
+            padding: 0.5rem 0.75rem;
+            justify-content: center;
+            align-items: center;
+            gap: 0.625rem;
+            flex: 1 0 0;
+            color: $gray-100;
+
+            /* Body S */
+            font-family: $libre-franklin;
+            font-size: 1rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 1.5rem; /* 150% */
+          }
+
+          .quota-select input[type="radio"]:checked + label {
+            border-radius: 0.5rem;
+            border: 1px solid $princeton-orange;
+            background: $white;
+          }
+
+          .hidden-div {
+            display: flex;
+            align-items: center;
+            gap: 2.5rem;
+            align-self: stretch;
+
+            .custom-quota {
+              display: flex;
+              align-items: center;
+              gap: 0.5rem;
+              flex: 1 0 0;
+              width: 100%;
+              padding: 1rem;
+            }
+          }
+        }
+
+        .selected-items {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.25rem;
+          list-style-type: none;
+          padding-left: 0;
+          width: 100%;
+
+          .selected-item {
+            display: flex;
+            height: 2.25rem;
+            padding: 0.25rem 0.75rem;
+            align-items: center;
+            gap: 1.25rem;
+            border-radius: 0.25rem;
+            background: $gray-10;
+            width: 100%;
+          }
+        }
+        .remove-item {
+          width: 1rem;
+          height: 1rem;
+          flex-shrink: 0;
+          cursor: pointer;
+          background: url("remove.svg") no-repeat;
         }
       }
 
@@ -536,6 +537,10 @@
             align-self: stretch;
             .form-field {
               flex-direction: column;
+              display: flex;
+              align-items: flex-start;
+              gap: 1.25rem;
+              align-self: stretch;
 
               .field-info {
                 width: auto;

--- a/app/views/new_project_wizard/_review_and_submit_form.html.erb
+++ b/app/views/new_project_wizard/_review_and_submit_form.html.erb
@@ -9,6 +9,7 @@
                                                                                 parent_folder: @request_model.parent_folder || "", parent_folder_error: @request_model.errors[:parent_folder].join(", ")} %>
     <%= render partial: "/new_project_wizard/form_project_description_input", locals: {description: @request_model.description || "", description_error: @request_model.errors[:description].join(", ") } %>
     <%= render partial: "/new_project_wizard/form_department_input", locals: {departments: @request_model.departments || [], department_error: @request_model.errors[:departments].join(", ") } %>
+</div>
 <div class="section-line"></div>
 <div class="section">
     <div class="section-title">


### PR DESCRIPTION
This allows it to be applied to the title field in the save and exit modal as well as the form fields. 

Additionally added the missing closing div on the review and submit form.

The missing div made the modal look correct on the review screen without the change to CSS

Before the PR:
<img width="792" height="326" alt="Screenshot 2025-09-11 at 11 45 21 AM" src="https://github.com/user-attachments/assets/56f00aa8-5392-4baa-94bb-e89698e6577e" />
After the PR:

<img width="842" height="409" alt="Screenshot 2025-09-11 at 11 44 58 AM" src="https://github.com/user-attachments/assets/f746ed57-b759-4ce4-bb7a-3f985fe10f5e" />
