### PR TITLE
Removing New project button as that is no longer available

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,7 +5,3 @@
     <%= link_to(project.title, project) %> <br/>
   <% end %>
 </div>
-
-<div>
-  <%= link_to "New Project", new_project_path(), class: "btn btn-primary btn-sm" %>
-</div>

--- a/spec/system/project_index_spec.rb
+++ b/spec/system/project_index_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Project Index Page", type: :system do
+  context "unauthenticated user" do
+    it "shows the 'Log In' button" do
+      visit projects_path
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "authenticated user" do
+    let(:current_user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+    let(:project_not_in_mediaflux) { FactoryBot.create(:project, data_sponsor: "pul123", data_manager: "pul123") }
+
+    before do
+      sign_in current_user
+      project_not_in_mediaflux
+    end
+
+    it "shows the existing projects" do
+      visit "/projects"
+      expect(page).to have_content("Access Denied")
+      expect(page).to have_content(project_not_in_mediaflux.title)
+    end
+  end
+
+  context "system admin user" do
+    let(:current_user) { FactoryBot.create(:sysadmin, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+    let(:project_not_in_mediaflux) { FactoryBot.create(:project, data_sponsor: "pul123", data_manager: "pul123") }
+
+    before do
+      sign_in current_user
+      project_not_in_mediaflux
+    end
+
+    it "shows the existing projects" do
+      visit "/projects"
+      expect(page).not_to have_content("Access Denied")
+      expect(page).to have_link(project_not_in_mediaflux.title)
+    end
+  end
+end

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -82,18 +82,6 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
     end
   end
 
-  context "Index page" do
-    before do
-      project_not_in_mediaflux
-    end
-
-    it "shows the existing projects" do
-      sign_in sponsor_user
-      visit "/projects"
-      expect(page).to have_content(project_not_in_mediaflux.title)
-    end
-  end
-
   context "GET /projects/:id" do
     context "when authenticated" do
       let!(:sponsor_and_data_manager_user) { FactoryBot.create(:sponsor_and_data_manager, uid: "tigerdatatester", mediaflux_session: SystemUser.mediaflux_session) }


### PR DESCRIPTION
All projects are created via a request
fixes #1838