### PR TITLE
Allow datausers to be blank without throwing an exception

### DIFF
--- a/app/services/request_project_metadata.rb
+++ b/app/services/request_project_metadata.rb
@@ -36,10 +36,12 @@ class RequestProjectMetadata
        end
 
        def read_only_users(request)
+         return [] if request[:user_roles].blank?
          request[:user_roles].select { |u| u["read_only"] || u["read_only"].nil? }.map { |u| u["uid"] }
        end
 
        def read_write_users(request)
+         return [] if request[:user_roles].blank?
          request[:user_roles].select { |u| u["read_only"] == false }.map { |u| u["uid"] }
        end
 


### PR DESCRIPTION
In writing a test for another issue I found that we could no longer create a project in mediaflux from a request that contains no datausers.