### PR TITLE
A UI to allow queries to be sent to medaiflux

### DIFF
--- a/app/controllers/aql_queries_controller.rb
+++ b/app/controllers/aql_queries_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class AqlQueriesController < ApplicationController
+  # GET /aql_queries or /aql_queries.json
+  def index
+    @aql_query = params[:aql_query]
+    if @aql_query.blank?
+      @results = []
+    else
+      query = Mediaflux::QueryRequest.new(session_token: current_user.mediaflux_session, aql_query: @aql_query, iterator: false)
+      if query.error?
+        @results = []
+        flash[:notice] = query.response_error[:message][1..250]
+      else
+        flash[:notice] = nil
+        @results = query.result_items
+      end
+    end
+  end
+end

--- a/app/views/aql_queries/index.html.erb
+++ b/app/views/aql_queries/index.html.erb
@@ -1,0 +1,29 @@
+
+<% content_for :title, "Aql query for mediaflux" %>
+
+<h1>Type a query into the box and see what mediaflux spits out</h1>
+
+<h2>Example queries </h2>
+ <ul>
+  <li> xpath(tigerdata:project/Title) contains-all ignore-case 'juice apple' </li>
+  <li> xpath(tigerdata:project/Title) matches ignore-case '*juice apple*' </li>
+  <li> xpath(tigerdata:project/Title) starts with ignore-case 'bottle' </li>
+  <li> xpath(tigerdata:project/Title) contains-any ignore-case 'bottle can' </li>
+ <ul>
+
+
+<h2>Search </h2>
+<%= form_with url: aql_queries_path, method: :get do |form| %>
+  <%= form.label :query, "Search Mediaflux for:" %>
+  <%= form.search_field :aql_query, value: @aql_query, style: "width: 100%" %>
+  <%= form.submit "Search" %>
+<% end %>
+<p/>
+<h2> Results </h2>
+<ul>
+  <% @results.each do |result| %>
+    <li>
+     <%= result.to_json %>
+    </li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,8 @@ Rails.application.routes.draw do
 
   get "request_submit", to: "request_submit#index"
 
+  get "aql_queries", to: "aql_queries#index"
+
   # Catch any undefined path and render a 404 page not found
   get "*path", to: "application#render_not_found"
 end


### PR DESCRIPTION
refs #1929

@bess asked for a UI to be able to send queries to mediaflux and see what comes out.

I spent a couple hours digging into what a query for a title would look like and then implementing a UI.

Hopefully this is useful in the spike

The UI contains an example query to match all the query terms in any order
<img width="978" height="434" alt="Screenshot 2025-10-03 at 9 53 03 AM" src="https://github.com/user-attachments/assets/35c910dc-df92-4a7a-8371-92609d918b74" />
