### PR TITLE
Switch to using gem.coop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source "https://gem.coop"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop/
   specs:
     actioncable (7.2.2.2)
       actionpack (= 7.2.2.2)


### PR DESCRIPTION
Let's switch to gem.coop. 

This is them: https://gem.coop/

Context: https://www.heise.de/en/news/Who-owns-an-open-source-project-RubyGems-threatens-to-split-10685184.html