### PR TITLE
Make hover more noticeable on secondary buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -175,5 +175,6 @@ h6 {
 
 .pul-button-secondary:hover {
   text-decoration-color: $gray-100 !important;
-  color: $gray-100;
+  color: $white;
+  background-color: $black-hover;
 }


### PR DESCRIPTION
fixes #1976
## no hover
<img width="208" height="81" alt="Screenshot 2025-10-14 at 2 37 46 PM" src="https://github.com/user-attachments/assets/53fbeaa2-e653-448d-aeac-7a3a640fe2b3" />

## hover
<img width="283" height="134" alt="Screenshot 2025-10-14 at 2 37 34 PM" src="https://github.com/user-attachments/assets/7efd2886-4ca5-43e0-af61-4a38e93e5c9c" />
