### PR TITLE
Restores functionality that allows user to jump between steps of the Wizard and save the current state

### DIFF
--- a/app/views/new_project_wizard/_sidebar.html.erb
+++ b/app/views/new_project_wizard/_sidebar.html.erb
@@ -62,6 +62,9 @@
     // ...and instead submit the form but indicating via the submit's button value property
     // what step we want to go after saving the data
     var submitButton = document.querySelectorAll('input[type=submit][value=Next]')[0];
+    if (submitButton === undefined) {
+        submitButton = document.querySelectorAll('input[type=submit][value=Submit]')[0];
+    }
     var stepToGoTo = event.target.href;
     submitButton.value = stepToGoTo;
     submitButton.click();


### PR DESCRIPTION
We broke the code that allowed the Wizard to save the data when the user jumped between steps, I think because we changed the label from Next to Submit of the button and the JavaScript functionality was expecting the button to always be "Next" (maybe on this PR https://github.com/pulibrary/tigerdata-app/pull/2023). 

This PR fixes that. We should probably add a test for this, but I just wanted to fix the functionality right away.