### PR TITLE
Remove tests for special behavior in production

### DIFF
--- a/spec/controllers/new_request_wizard/project_information_controller_spec.rb
+++ b/spec/controllers/new_request_wizard/project_information_controller_spec.rb
@@ -21,20 +21,9 @@ RSpec.describe NewProjectWizard::ProjectInformationController, type: :controller
       end
 
       context "a sysadmin" do
-        it "shows the form" do
+        it "can see the project show page" do
           get :show, params: { request_id: valid_request.id }
           expect(response).not_to have_http_status(:redirect)
-        end
-
-        context "the production environment" do
-          before do
-            allow(Rails.env).to receive(:production?).and_return(true)
-          end
-
-          it "shows the form" do
-            get :show, params: { request_id: valid_request.id }
-            expect(response).not_to have_http_status(:redirect)
-          end
         end
       end
 
@@ -89,25 +78,6 @@ RSpec.describe NewProjectWizard::ProjectInformationController, type: :controller
           it "shows the form when the request id is blank" do
             get :show, params: {}
             expect(response).not_to have_http_status(:redirect)
-          end
-        end
-
-        context "the production environment" do
-          before do
-            allow(Rails.env).to receive(:production?).and_return(true)
-          end
-
-          it "shows the form" do
-            get :show, params: { request_id: valid_request.id }
-            expect(response).not_to have_http_status(:redirect)
-          end
-
-          it "redirects to the dashboard when the flipper is off" do
-            test_strategy = Flipflop::FeatureSet.current.test!
-            test_strategy.switch!(:allow_all_users_wizard_access, false)
-            get :show, params: { request_id: valid_request.id }
-            expect(response).to redirect_to "http://test.host/dashboard"
-            test_strategy.switch!(:allow_all_users_wizard_access, true)
           end
         end
       end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     given_name { display_name.split(" ").first }
     family_name { display_name.split(" ").last }
     provider { :cas }
-    email { "#{uid}@example.com" }
+    sequence(:email) { |n| "#{uid}@example#{n}.com" } # Ensure unique emails
     eligible_sponsor { false }
     eligible_manager { false }
     sysadmin { false }


### PR DESCRIPTION
...because everything should match now anyway, and these tests are flaky and order dependent.

The order dependency can be re-created with this command:
> be rspec --seed 28249 spec/controllers/new_request_wizard/

Also, there are sometimes errors related to email addresses not being unique, so this ensures email addresses are always unique. 

Ref #2065 