### PR TITLE
Show uid matches before name matches

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,9 +92,9 @@ class User < ApplicationRecord
   # Return the display name if it exists, otherwise return the uid
   # @return [String]
   def display_name_safe
-    return uid if display_name.blank?
+    return uid if given_name.blank? && family_name.blank?
 
-    "#{display_name} (#{uid})"
+    [given_name, family_name, "(#{uid})"].compact.join(" ")
   end
 
   # Is this user eligible to be a data sponsor in this environment?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  let(:access_token) { OmniAuth::AuthHash.new(provider: "cas", uid: "who", extra: { mail: "who@princeton.edu", givenname: "guess", sn: "who", pudisplayname: "Guess Who?" }) }
+  let(:access_token) { OmniAuth::AuthHash.new(provider: "cas", uid: "who", extra: { mail: "who@princeton.edu", givenname: "Guess", sn: "Who?", pudisplayname: "Guess Who?" }) }
   let(:access_token2) { OmniAuth::AuthHash.new(provider: "cas", uid: "who2", extra: { mail: "who2@princeton.edu" }) }
   let(:access_token3) { OmniAuth::AuthHash.new(provider: "cas", uid: "who3", extra: { mail: "who3@princeton.edu", givenname: "", sn: "", pudisplayname: "" }) }
   let(:access_token4) { OmniAuth::AuthHash.new(provider: "cas", uid: "who4", extra: { mail: "who4@princeton.edu", givenname: "Guess", sn: "McWho", pudisplayname: "Guess McWho" }) }
@@ -28,8 +28,8 @@ RSpec.describe User, type: :model do
       user = described_class.from_cas(access_token)
       expect(user).to be_a described_class
       expect(user.uid).to eq("who")
-      expect(user.given_name).to eq("guess")
-      expect(user.family_name).to eq("who")
+      expect(user.given_name).to eq("Guess")
+      expect(user.family_name).to eq("Who?")
       expect(user.display_name).to eq("Guess Who?")
     end
   end
@@ -39,8 +39,8 @@ RSpec.describe User, type: :model do
       user = described_class.from_cas(access_token)
       expect(user).to be_a described_class
       expect(user.uid).to eq("who")
-      expect(user.given_name).to eq("guess")
-      expect(user.family_name).to eq("who")
+      expect(user.given_name).to eq("Guess")
+      expect(user.family_name).to eq("Who?")
       expect(user.display_name_safe).to eq("Guess Who? (who)")
     end
     it "testing a uid" do

--- a/spec/presenters/request_presenter_spec.rb
+++ b/spec/presenters/request_presenter_spec.rb
@@ -104,6 +104,8 @@ describe RequestPresenter, type: :model, connect_to_mediaflux: false do
 
     it "returns the uid if the full name is not found" do
       current_user.display_name = nil
+      current_user.given_name = nil
+      current_user.family_name = nil
       current_user.save!
       expect(presenter.full_name(current_user.uid)).to eq(current_user.uid)
     end

--- a/spec/services/princeton_users_spec.rb
+++ b/spec/services/princeton_users_spec.rb
@@ -190,12 +190,12 @@ RSpec.describe PrincetonUsers, type: :model do
   end
 
   describe "#user_list_query" do
-    let(:user) { { uid: "sms98", name: "Sotomayor, Sonia", display_name: "Sotomayor, Sonia (sms98)" } }
+    let(:user) { { uid: "sms98", name: "Sotomayor, Asonia", display_name: "Sotomayor, Asonia (sms98)" } }
     let(:user_no_name) { { uid: "sms99", name: nil, display_name: "sms99" } }
 
     before do
       FactoryBot.create(:user, uid: "sms99", display_name: nil, given_name: nil, family_name: nil)
-      FactoryBot.create(:user, uid: "sms98", display_name: "Sotomayor, Sonia")
+      FactoryBot.create(:user, uid: "sms98", display_name: "Sotomayor, Asonia")
     end
 
     it "detect matches by uid" do
@@ -206,9 +206,10 @@ RSpec.describe PrincetonUsers, type: :model do
       expect(described_class.user_list_query("abc")).to eq []
     end
 
-    it "detect matches by uid" do
-      FactoryBot.create(:user, uid: "asms99", display_name: "Anna", given_name: nil, family_name: nil)
-      expect(described_class.user_list_query("sms")).to eq [{ display_name: "Anna (asms99)", name: "Anna", uid: "asms99" }, user, user_no_name]
+    it "detect matches by uid and puts them first" do
+      FactoryBot.create(:user, uid: "oto99", display_name: "Anna Smsath", given_name: "Anna", family_name: "Smsath")
+      expect(described_class.user_list_query("sms")).to eq [user, user_no_name, { display_name: "Anna Smsath (oto99)", name: "Anna Smsath", uid: "oto99" }]
+      expect(described_class.user_list_query("oto")).to eq [{ display_name: "Anna Smsath (oto99)", name: "Anna Smsath", uid: "oto99" }, user]
     end
 
     it "does not query if no tokens are present" do


### PR DESCRIPTION
Also display the Given Name Family Name in order instead of utilizing the display name.  It seems the display name is in Last Name, First Name order some times.

fixes #2077 
refs #2020

## Before the change
<img width="919" height="1074" alt="Screenshot 2025-10-23 at 10 36 34 AM" src="https://github.com/user-attachments/assets/9bacea52-5122-4e42-b1c5-78e381e653a4" />

## after the change

<img width="952" height="1085" alt="Screenshot 2025-10-23 at 1 37 23 PM" src="https://github.com/user-attachments/assets/86ca1cc0-5868-43f9-a2a8-28c34a0683c5" />
