### PR TITLE
Downgrade openssl to allow access to LDAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,12 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# OpenSSL 3.6 broke Ruby's OpenSSL bindings, see: https://github.com/ruby/openssl/issues/949
+# By using the openssl gem, we can pick up the fixes without needing to upgrade Ruby.
+# This gem line can be removed once we upgrade to Ruby 3.4 >= 3.4.8, or Ruby 3.3 >= 3.3.10 or Ruby 3.2 >= 3.2.10
+# which will include the openssl fix by default, see: https://github.com/ruby/openssl/issues/949#issuecomment-3388132260
+gem "openssl", ">= 3.3.1"
+
 gem "bootstrap", "~> 5.2.0"
 gem "vite_rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,7 @@ GEM
       addressable (~> 2.8)
       nokogiri (~> 1.12)
       omniauth (~> 2.1)
+    openssl (3.3.2)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -646,6 +647,7 @@ DEPENDENCIES
   net-http-persistent
   net-ldap
   omniauth-cas (~> 3.0)
+  openssl (>= 3.3.1)
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
taken from https://github.com/code-dot-org/code-dot-org/pull/68921/files

fixes `SSL_connect returned=1 errno=0 peeraddr=140.180.222.45:636 state=error: certificate verify failed (unable to get certificate CRL)`