### PR TITLE
Make sure all projects are fetched (not only the first 100)

### DIFF
--- a/app/models/mediaflux/project_list_request.rb
+++ b/app/models/mediaflux/project_list_request.rb
@@ -19,7 +19,7 @@ module Mediaflux
       @deep_search = deep_search
       # For now we hard-code the size to infinity since only Administrators will fetch a large
       # number of projects and they should get them all. At some point in the future we might
-      # want to implement pagination for this list but not now.
+      # want to implement pagination for this list but not now..
       @size = "infinity"
     end
 


### PR DESCRIPTION
This fixes an issue we noted while testing in Staging since Administrators should be able to fetch all projects that they have access to, not only the first 100 (which is the default when not indicating a `size` parameter to Mediaflux.)