### PR TITLE
Set the displayed value to the entire name

### DIFF
--- a/app/javascript/entrypoints/userRolesAutocomplete.js
+++ b/app/javascript/entrypoints/userRolesAutocomplete.js
@@ -205,7 +205,9 @@ export function userRolesAutocomplete(usersLookupUrl) {
     if (userSelectedValue === true) {
       const elementSelected = $(`${element} [value="${value}"]`);
       const current = event.currentTarget;
-      current.value = elementSelected.data('uid');
+      const currentHidden = $(`#${current.id}_uid`)[0];
+      current.value = elementSelected.data('name');
+      currentHidden.value = elementSelected.data('uid');
       event.preventDefault();
     } else {
       debouncedSearch(value, element);

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -154,7 +154,25 @@ class Request < ApplicationRecord
     User.find_by(uid: requested_by).display_name_safe
   end
 
+  def data_manager_name
+    user_name(data_manager)
+  end
+
+  def data_sponsor_name
+    user_name(data_sponsor)
+  end
+
   private
+
+    def user_name(uid)
+      return "" if uid.blank?
+      user = User.find_by(uid: uid)
+      if user.present?
+        user.display_name_safe
+      else
+        uid
+      end
+    end
 
     def check_errors?
       original_error_count = errors.count

--- a/app/views/new_project_wizard/_form_data_manager_input.html.erb
+++ b/app/views/new_project_wizard/_form_data_manager_input.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "/new_project_wizard/form_field_label",
            locals: {field_label: "Data Manager", field_sub_label: "Required"} %>
   <%= render partial: "/new_project_wizard/form_user_input",
-           locals: {field_name: "data_manager", field_value: data_manager, field_error: data_manager_error,
+           locals: {field_name: "data_manager", field_value: data_manager_name, field_error: data_manager_error, field_id_value: data_manager,
                     tooltip: "The steward of a TigerData project; responsible for project data management, metadata entry, policy compliance, data movement, and more."
                     } %>
 </div>

--- a/app/views/new_project_wizard/_form_data_sponsor_input.html.erb
+++ b/app/views/new_project_wizard/_form_data_sponsor_input.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "/new_project_wizard/form_field_label",
            locals: {field_label: "Data Sponsor", field_sub_label: "Required"} %>
   <%= render partial: "/new_project_wizard/form_user_input",
-          locals: {field_name: "data_sponsor", field_value: data_sponsor, field_error: data_sponsor_error,
+          locals: {field_name: "data_sponsor", field_value: data_sponsor_name, field_error: data_sponsor_error, field_id_value: data_sponsor,
                   tooltip: "A permanent Princeton University employee who owns, provides oversight, and is responsible for the TigerData project."
                   } %>
 

--- a/app/views/new_project_wizard/_form_user_input.html.erb
+++ b/app/views/new_project_wizard/_form_user_input.html.erb
@@ -5,8 +5,10 @@
           <div class="pul-tooltip">
             <span class="pul-tooltiptext"><%= tooltip %></span>
           </div>
-          <input class="form-input <%= field_name %>" type="text" name="request[<%= field_name %>]" id="request_<%= field_name %>"
-                list="<%= field_name %>s" placeholder="Select a Data Manager" autocomplete="off" value="<%= field_value %>"></input>
+          <input class="form-input <%= field_name %>" type="text" id="request_<%= field_name %>"
+                list="<%= field_name %>s" placeholder="Select a Data Manager" autoComplete="off" value="<%= field_value %>">
+          </input>
+          <input type="hidden" name="request[<%= field_name %>]" id="request_<%= field_name %>_uid" value="<%= field_id_value %>"></input>
           <!-- This datalist is populated via AJAX in userRolesAutocomplete() -->
           <datalist id="<%= field_name %>s"></datalist>
           <div class="input-error">

--- a/app/views/new_project_wizard/_review_and_submit_form.html.erb
+++ b/app/views/new_project_wizard/_review_and_submit_form.html.erb
@@ -18,8 +18,10 @@
       Roles and People
       </div>
     </div>
-    <%= render partial: "/new_project_wizard/form_data_sponsor_input", locals: {data_sponsor: @request_model.data_sponsor || "", data_sponsor_error: @request_model.errors[:data_sponsor].join(", ") } %>
-    <%= render partial: "/new_project_wizard/form_data_manager_input", locals: {data_manager: @request_model.data_manager || "", data_manager_error: @request_model.errors[:data_manager].join(", ") } %>
+    <%= render partial: "/new_project_wizard/form_data_sponsor_input", 
+               locals: {data_sponsor: @request_model.data_sponsor || "", data_sponsor_name: @request_model.data_sponsor_name, data_sponsor_error: @request_model.errors[:data_sponsor].join(", ") } %>
+    <%= render partial: "/new_project_wizard/form_data_manager_input", 
+               locals: {data_manager: @request_model.data_manager || "", data_manager_name: @request_model.data_manager_name, data_manager_error: @request_model.errors[:data_manager].join(", ") } %>
     <%= render partial: "/new_project_wizard/form_user_roles_input", locals: {user_roles: @request_model.user_roles || [], user_roles_error: @request_model.errors[:user_roles].join(", ") } %>
 </div>
 <div class="section-line"></div>

--- a/app/views/new_project_wizard/roles_and_people.html.erb
+++ b/app/views/new_project_wizard/roles_and_people.html.erb
@@ -2,8 +2,10 @@
 <% content_for :form_title, "Roles and People" %>
 <% content_for :form_description, "Assign roles for your project." %>
 
-<%= render partial: "/new_project_wizard/form_data_sponsor_input", locals: {data_sponsor: @request_model.data_sponsor || "", data_sponsor_error: "" } %>
-<%= render partial: "/new_project_wizard/form_data_manager_input", locals: {data_manager: @request_model.data_manager || "", data_manager_error: "" } %>
+<%= render partial: "/new_project_wizard/form_data_sponsor_input", 
+            locals: {data_sponsor: @request_model.data_sponsor || "", data_sponsor_name: @request_model.data_sponsor_name, data_sponsor_error: @request_model.errors[:data_sponsor].join(", ") } %>
+<%= render partial: "/new_project_wizard/form_data_manager_input", 
+            locals: {data_manager: @request_model.data_manager || "", data_manager_name: @request_model.data_manager_name, data_manager_error: @request_model.errors[:data_manager].join(", ") } %>
 <%= render partial: "/new_project_wizard/form_user_roles_input", locals: {user_roles: @request_model.user_roles || [], user_roles_error: "" } %>
 
 <script type="module">

--- a/spec/support/select_user.rb
+++ b/spec/support/select_user.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+def select_user(user, field, hidden_field)
+  name_with_space = user.display_name_safe + "\u00A0"
+
+  option_string = "<option data-uid=\"#{user.uid}\" data-name=\"#{user.display_name_safe}\" value=\"#{user.display_name_safe + "&nbsp\;"}\">"
+
+  # Fill in a partial match to force the textbox to fetch a list of options to select from
+  fill_in field, with: user.uid[0]
+  fill_in field, with: user.uid
+  sleep(0.6) # allow for debounce
+  wait_for_option(option_string)
+
+  select name_with_space, from: field
+  expect(page).to have_field(field, with: user.display_name_safe)
+  expect(page).to have_field(hidden_field, type: "hidden", with: user.uid)
+end
+
+def wait_for_option(option_string)
+  count = 5
+  while (count > 0) && body.exclude?(option_string)
+    sleep(0.1) # allow for values to return
+    count -= 1
+  end
+
+  unless body.include?(option_string)
+    puts "This will error"
+    puts page.driver.browser.logs.get(:browser)
+  end
+end

--- a/spec/system/new_project_request_wizard_spec.rb
+++ b/spec/system/new_project_request_wizard_spec.rb
@@ -191,17 +191,9 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
       # expect(page).to have_content "Dates (Optional)"
       # click_on "Next"
       expect(page).to have_content("Assign roles for your project")
-      current_user_str = current_user.display_name_safe
 
-      # Fill in a partial match to force the textbox to fetch a list of options to select from
-      fill_in :request_data_sponsor, with: current_user.uid
-      sleep(1.5)
-      select current_user_str + "\u00A0", from: "request_data_sponsor"
-
-      # Fill in a partial match to force the textbox to fetch a list of options to select from
-      fill_in :request_data_manager, with: current_user.uid
-      sleep(1.2)
-      select current_user_str + "\u00A0", from: "request_data_manager"
+      select_user(current_user, "request_data_sponsor", "request[data_sponsor]")
+      select_user(current_user, "request_data_manager", "request[data_manager]")
 
       # Fill in a partial match to force the textbox to fetch a list of options to select from
       click_on "Add User(s)"
@@ -217,6 +209,8 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
       expect(page).to have_field("request[user_roles][]", type: :hidden, with: "{\"uid\":\"#{another_user.uid}\",\"name\":\"#{another_user.display_name_safe}\"}")
       page.find(".remove-user-role").click
       expect(page).not_to have_content(another_user_str)
+
+      current_user_str = current_user.display_name_safe
 
       fill_in :user_find, with: current_user.uid
       sleep(1.2)
@@ -266,11 +260,13 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
       expect(page).to have_content("Assign roles for your project")
       expect(page).to have_content "Roles and People"
       expect(page).to have_content "Data Manager"
-      expect(page).to have_field("request_data_sponsor", with: current_user.uid)
-      expect(page).to have_field("request_data_manager", with: current_user.uid)
+      expect(page).to have_field("request_data_sponsor", with: current_user.display_name_safe)
+      expect(page).to have_field("request[data_sponsor]", type: :hidden, with: current_user.uid)
+      expect(page).to have_field("request_data_manager", with: current_user.display_name_safe)
+      expect(page).to have_field("request[data_manager]", type: :hidden, with: current_user.uid)
       expect(page).to have_field("request[user_roles][]", type: :hidden, with: "{\"uid\":\"#{current_user.uid}\",\"name\":\"#{current_user.display_name_safe}\",\"read_only\":false}")
       expect(page).to have_field("request[user_roles][]", type: :hidden, with: "{\"uid\":\"#{other_user.uid}\",\"name\":\"#{other_user.display_name_safe}\",\"read_only\":true}")
-      expect(page).not_to have_content("#{current_user_str} (#{current_user.uid})")
+      expect(page).not_to have_content("#{current_user.display_name_safe} (#{current_user.uid})")
     end
 
     it "saves work in progress if user jumps to another step in the wizard" do

--- a/spec/system/request_spec.rb
+++ b/spec/system/request_spec.rb
@@ -18,7 +18,7 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
     let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin", mediaflux_session: SystemUser.mediaflux_session) }
     let(:developer) { FactoryBot.create(:developer, uid: "root", mediaflux_session: SystemUser.mediaflux_session) }
     let!(:data_manager) { FactoryBot.create(:data_manager, uid: "rl3667", mediaflux_session: SystemUser.mediaflux_session) }
-    let(:request) { Request.create(request_title: "abc123", project_title: "project") }
+    let(:request) { Request.create(request_title: "abc123", project_title: "project", requested_by: current_user.uid, project_folder: "folder123") }
     let(:full_request) do
       Request.create(
         request_type: nil,

--- a/spec/system/skeletor_spec.rb
+++ b/spec/system/skeletor_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe "The Skeletor Epic", connect_to_mediaflux: true, js: true, integr
       expect(page).to have_content("(77777) RDSS-Research Data and Scholarship Services")
       expect(page).to have_field("request[departments][]", type: :hidden, with: "{\"code\":\"77777\",\"name\":\"RDSS-Research Data and Scholarship Services\"}")
       click_on "Roles and People"
-      fill_in :request_data_sponsor, with: datasponsor.uid
-      fill_in :request_data_manager, with: datamanager.uid
+      select_user(datasponsor, "request_data_sponsor", "request[data_sponsor]")
+      select_user(datamanager, "request_data_manager", "request[data_manager]")
       click_on "Review and Submit"
       expect(page).to have_content "Take a moment to review"
       click_on "Submit"
@@ -97,8 +97,8 @@ RSpec.describe "The Skeletor Epic", connect_to_mediaflux: true, js: true, integr
       expect(page).to have_content("(77777) RDSS-Research Data and Scholarship Services")
       expect(page).to have_field("request[departments][]", type: :hidden, with: "{\"code\":\"77777\",\"name\":\"RDSS-Research Data and Scholarship Services\"}")
       click_on "Roles and People"
-      fill_in :request_data_sponsor, with: datasponsor.uid
-      fill_in :request_data_manager, with: datamanager.uid
+      select_user(datasponsor, "request_data_sponsor", "request[data_sponsor]")
+      select_user(datamanager, "request_data_manager", "request[data_manager]")
       click_on "Review and Submit"
       expect(page).to have_content "Take a moment to review"
       click_on "Submit"

--- a/spec/system/space_ghost_spec.rb
+++ b/spec/system/space_ghost_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "The Space Ghost Epic", type: :system, connect_to_mediaflux: fals
 
       # This part of the test is filling out the data manager and sponsor
       expect(page).to have_content("Assign roles for your project")
-      fill_in :request_data_sponsor, with: datasponsor.uid
-      fill_in :request_data_manager, with: datamanager.uid
+      select_user(datasponsor, "request_data_sponsor", "request[data_sponsor]")
+      select_user(datamanager, "request_data_manager", "request[data_manager]")
 
       # This part of the test is filling out the data users
       click_on "Add User(s)"


### PR DESCRIPTION
Centralize the view and javascript for data manager and sponsor
Set the displayed value to the entire name and have a hidden field with the uid

fix spec error "not to search for nil"
<img width="1707" height="1085" alt="Screenshot 2025-11-05 at 2 38 43 PM" src="https://github.com/user-attachments/assets/82278712-d16d-4b58-8b9c-5c33587a7810" />

