### PR TITLE
Fixes alignment issue in Show page

### DIFF
--- a/app/views/projects/_approved_details.html.erb
+++ b/app/views/projects/_approved_details.html.erb
@@ -24,11 +24,12 @@
             </div>
         </dl>
     </dd>
+    <!-- The HTML &nbsp; is to make sure the `dd` element aligns with the proper `dt` when is empty -->
     <dt>Project Purpose</dt>
-    <dd><%= @presenter.project_purpose %></dd>
+    <dd><%= @presenter.project_purpose %>&nbsp;</dd>
 
     <dt>Estimated number of files</dt>
-    <dd><%= @presenter.number_of_files %></dd>
+    <dd><%= @presenter.number_of_files %>&nbsp;</dd>
 
     <dt>High Performance Computing</dt>
     <dd><%= @presenter.hpc %></dd>


### PR DESCRIPTION
Fixes the alignment issue for the "Project Purpose" and "Estimated number of files" when these values are empty in Mediaflux. These fields were added later in the process and we have a few projects with empty values in Mediaflux.

<img width="782" height="466" alt="Screenshot 2025-11-05 at 5 11 05 PM" src="https://github.com/user-attachments/assets/bb799f70-83ad-445a-bf3e-b83d5616782d" />

Closes #2152 