### PR TITLE
Refactoring to allow easier integration of the new LUX widget

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -40,10 +40,6 @@ window.showMoreLess = showMoreLess;
 window.projectStyle = projectStyle;
 window.projectTab = projectTab;
 
-// This makes userRolesAutocomplete available as a script module which allows us
-// to pass Rails parameters from the view to the JavaScript code.
-window.userRolesAutocomplete = userRolesAutocomplete;
-
 async function fetchListContents(listContentsPath) {
   const response = await fetch(listContentsPath);
 
@@ -208,6 +204,7 @@ function initPage() {
   departmentAutocomplete();
   validationClear();
   titleCopySaveExit();
+  userRolesAutocomplete();
 }
 
 window.addEventListener('load', () => initPage());

--- a/app/javascript/entrypoints/userRolesAutocomplete.js
+++ b/app/javascript/entrypoints/userRolesAutocomplete.js
@@ -146,7 +146,8 @@ function moveNewUsers() {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function userRolesAutocomplete(usersLookupUrl) {
+export function userRolesAutocomplete() {
+  const usersLookupUrl = document.querySelector('#users_lookup_url').value;
   // Debounce is used to limit the number of times a function is called in a short period of time.
   // source: https://github.com/jrrio/datalist-autocomplete-ajax/blob/main/main.js#L159C3-L166C5
   // see also: https://www.geeksforgeeks.org/javascript/debouncing-in-javascript/

--- a/app/views/new_project_wizard/_review_and_submit_form.html.erb
+++ b/app/views/new_project_wizard/_review_and_submit_form.html.erb
@@ -37,6 +37,4 @@
 </div>
 <div class="section-line"></div>
 
-<script type="module">
-  userRolesAutocomplete("<%= users_lookup_url %>");
-</script>
+<input id="users_lookup_url" type="hidden" value="<%= users_lookup_url %>"/>

--- a/app/views/new_project_wizard/roles_and_people.html.erb
+++ b/app/views/new_project_wizard/roles_and_people.html.erb
@@ -8,6 +8,4 @@
             locals: {data_manager: @request_model.data_manager || "", data_manager_name: @request_model.data_manager_name, data_manager_error: @request_model.errors[:data_manager].join(", ") } %>
 <%= render partial: "/new_project_wizard/form_user_roles_input", locals: {user_roles: @request_model.user_roles || [], user_roles_error: "" } %>
 
-<script type="module">
-  userRolesAutocomplete("<%= users_lookup_url %>");
-</script>
+<input id="users_lookup_url" type="hidden" value="<%= users_lookup_url %>"/>


### PR DESCRIPTION
The lux widget takes the name of the routine to call when the input changes.  Making the url integrated with the page will allow us to more easily call the lookup routine

refs #2083