### PR TITLE
Include a custom app when logging in to Mediaflux

### DIFF
--- a/app/models/mediaflux/logon_request.rb
+++ b/app/models/mediaflux/logon_request.rb
@@ -73,6 +73,10 @@ module Mediaflux
                 xml.text(@identity_token)
               end
             end
+            # Include the "app" parameter in the login information.
+            # This information shows when analyzing sessions via `system.session.all.describe`
+            # but sadly it does NOT show when running `licence.holder.list`
+            xml.app "TDWEB"
           end
         end
       end


### PR DESCRIPTION
Include a custom `app` parameter when logging in to Mediaflux. This allows us to better track sessions that are coming in from the frontend vs other sessions with the following command from aTerm:

```
system.session.all.describe :app "TDWEB"
```

which hopefully will help when troubleshooting the issue with the licenses (#2189), although it is not clear to me how sessions and licenses relate to each other.
