### PR TITLE
Improve logging when deleting asset.query.iterators

### DIFF
--- a/app/models/mediaflux/iterator_destroy_request.rb
+++ b/app/models/mediaflux/iterator_destroy_request.rb
@@ -30,6 +30,12 @@ module Mediaflux
         super do |xml|
           xml.args do
             xml.id @iterator
+            # An iterator can be destroyed by Mediaflux when we have read all its contents.
+            # For example if an iterator query has only a few results and we read them all
+            # in the first iteration then Mediaflux deletes the iterator behind the scenes.
+            xml.send("ignore-missing") do
+              xml.text(true)
+            end
           end
         end
       end

--- a/spec/models/mediaflux/iterator_destroy_request_spec.rb
+++ b/spec/models/mediaflux/iterator_destroy_request_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Mediaflux::IteratorDestroyRequest, connect_to_mediaflux: true, ty
       expect(a_request(:post, mediaflux_url).with do |req|
         req.body.include?("service name=\"asset.query.iterator.destroy\"")
       end).to have_been_made
+
+      # This second test is to emulate deleting an iterator that Mediaflux deleted behind the scenes.
+      destroy_request_again = described_class.new(session_token: user.mediaflux_session, iterator: @iterator_id)
+      expect(destroy_request_again.error?).to be false
     end
   end
 end


### PR DESCRIPTION
When deleting an iterator we now ignore errors if the iterator is missing. This is because Mediaflux automatically deletes iterators when we have read all its contents which happens if the project has only a handful of files and they are read all at once in the first iteration. In that case we get the following error:

```
E, [2025-11-19T15:01:29.960006 #2438857] ERROR -- : [b6390527-4de0-4e5a-b5e3-f50585d45b5f]
Mediaflux error: arc.mf.server.Services$ExServiceError, call to service 'asset.query.iterator.destroy' failed:
The session does not have an iterator (id): 1
```

This is because Mediaflux automatically deletes the iterator as soon as we read all the files from the query. 
