### PR TITLE
Add a login and learn more actions to the welcome screen

### DIFF
--- a/app/assets/stylesheets/_welcome_portal.scss
+++ b/app/assets/stylesheets/_welcome_portal.scss
@@ -114,6 +114,45 @@
             }
           }
         }
+
+        .learn-more {
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          gap: 4px;
+          color: $gray-100;
+          text-align: center;
+          text-decoration: none;
+
+          /* Body S Bold */
+          font-family: "Libre Franklin";
+          font-size: 16px;
+          font-style: normal;
+          font-weight: 600;
+          line-height: 24px; /* 150% */
+          border: none;
+          background: $white;
+
+          &::after {
+            background-image: asset_url("open-icon.svg");
+            background-position: center center;
+            background-repeat: no-repeat;
+            background-size: contain;
+            content: "";
+            display: inline-block;
+            height: 12px;
+            margin-left: 8px;
+            position: relative;
+            width: 12px;
+          }
+        }
+        .welcome-actions {
+          display: flex;
+          flex-direction: row;
+          align-items: flex-start;
+          gap: 4px;
+          align-self: stretch;
+        }
       }
       .welcome-right {
         display: flex;

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -11,10 +11,11 @@
             <p>TigerData is a data management service for the Princeton research community that includes a suite of software tools and scalable, tiered storage to enable the organization, description, storage, sharing, and long-term sustainability of research and administrative data. </p>
             <p>It enables the things you want to do (with your data), and makes it easier to do the things you have to do.</p>
           </div>
-          <%= button_to "Learn More", "https://tigerdata.princeton.edu", class: "pul-button pul-button-primary", id: "learn-more-button" %>
-
-          <div class="welcome-warn">
-              <p>Log in is currently limited to early adopters. <%= link_to "Contact us", "mailto:td-frontend@princeton.edu" %> for more information.</p>
+          <div class="welcome-actions">
+            <% unless Flipflop.disable_login? %>
+              <%= button_to "Login", user_cas_omniauth_authorize_path, class: "pul-button pul-button-primary", id: "login-button" %>
+            <% end %>
+            <%= link_to "Learn More", "https://tigerdata.princeton.edu", class: "pul-button learn-more", id: "learn-more-button", target: "_blank" %>
           </div>
         </div>
       </div>

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -15,10 +15,9 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
 
     it "shows the 'Learn More' button, which goes to the TigerData service page" do
       visit "/"
-      expect(page).to have_button "Learn More"
-      primary_button = find("#learn-more-button")
-      expect(primary_button).to have_text "Learn More"
-      expect(find(".welcome-text > .button_to")[:action]).to eq "https://tigerdata.princeton.edu/"
+      expect(page).to have_button "Login"
+      expect(page).to have_link "Learn More", href: "https://tigerdata.princeton.edu"
+      expect(find("#login-button").ancestor("form")[:action]).to include "users/auth/cas"
     end
 
     it "forwards to login page" do


### PR DESCRIPTION
remove the early adopter information as that is no longer true

fixes #2176 

<img width="552" height="566" alt="Screenshot 2025-12-02 at 9 00 28 AM" src="https://github.com/user-attachments/assets/1b819c51-bb02-484d-8b67-58a247997fdd" />
