### PR TITLE
Remove hard coded padding to fix the width of the form

### DIFF
--- a/app/assets/stylesheets/_project.scss
+++ b/app/assets/stylesheets/_project.scss
@@ -240,10 +240,14 @@ copy-project-path-label-normal {
 .basic-details-fields {
   padding-top: 30px;
   list-style-type: none;
-  width: 75rem;
+  width: 100%;
   height: auto;
   flex-shrink: 0;
   padding-left: 0rem;
+}
+
+blockquote {
+  line-break: anywhere;
 }
 
 .detail-table-label {

--- a/app/assets/stylesheets/requests.scss
+++ b/app/assets/stylesheets/requests.scss
@@ -152,10 +152,6 @@
   display: flex;
 }
 
-.heading-text {
-  padding-right: 63.5rem;
-}
-
 .edit-link {
   @include heading-style;
   margin-bottom: 0rem;

--- a/app/views/projects/details.html.erb
+++ b/app/views/projects/details.html.erb
@@ -37,9 +37,9 @@
             <li class="detail-subheading">Project Purpose</li>
             <p class="detail-value" id="project-purpose-value">
                <% if @presenter.project_purpose.blank? %>
-               <strong class="px-0">&mdash;</strong>
+                 <strong class="px-0">&mdash;</strong>
                <% else %>
-               <%= @presenter.project_purpose %>
+                 <%= @presenter.project_purpose %>
                <% end %>
             </p>
          </div>
@@ -51,18 +51,18 @@
             <li class="detail-subheading">Department(s)</li>
             <p class="detail-value">
                <% if @presenter.departments.empty? %>
-               <strong class="px-0">&mdash;</strong>
+                 <strong class="px-0">&mdash;</strong>
                <% else %>
-                <div class="departments-group">
-                  <% @presenter.department_codes.each do |dept|%>
-                    <div class="departments-container">
-                      <lux-badge class="lux-badge lux-badge-white departments">
-                        <div class="badge-text"><%= dept.second %></div>
-                      </lux-badge>
-                      <div class="departments-name"><%= dept.first %> </div>
-                    </div>
-                  <%end%>
-                </div>
+                 <div class="departments-group">
+                   <% @presenter.department_codes.each do |dept|%>
+                     <div class="departments-container">
+                       <lux-badge class="lux-badge lux-badge-white departments">
+                         <div class="badge-text"><%= dept.second %></div>
+                       </lux-badge>
+                       <div class="departments-name"><%= dept.first %> </div>
+                     </div>
+                   <%end%>
+                 </div>
                <% end %>
             </p>
          </div>


### PR DESCRIPTION
also fixes details page overrun display issues

fixes #2217

## wizard after the change
<img width="936" height="811" alt="Screenshot 2025-12-03 at 8 55 01 AM" src="https://github.com/user-attachments/assets/2bdfb03f-5de4-4a52-a545-51b40f2e53c8" />


## Details after change
<img width="977" height="1228" alt="Screenshot 2025-12-03 at 8 50 04 AM" src="https://github.com/user-attachments/assets/8598b074-0d97-481d-8f99-9b583170b970" />

## Details Before the change
<img width="915" height="1214" alt="Screenshot 2025-12-03 at 8 50 49 AM" src="https://github.com/user-attachments/assets/7c2689a9-9e02-4684-a98d-e92cf4122d2c" />
<img width="923" height="1217" alt="Screenshot 2025-12-03 at 8 50 58 AM" src="https://github.com/user-attachments/assets/7949f71b-c149-46fc-9259-a20ed48e7092" />

