### PR TITLE
Fixing widths via align-self stretch

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -219,7 +219,8 @@
         .input-frame {
           display: flex;
           flex-direction: column;
-          align-items: flex-start;
+          width: 100%;
+          padding-right: 10px;
           gap: 0.5rem;
           flex: 1 0 0;
           .text-input {
@@ -240,9 +241,9 @@
                 flex: 1 0 0;
                 .form-input {
                   display: flex;
-                  width: 36.875rem;
+                  align-self: stretch;
                   flex-direction: column;
-                  align-items: flex-start;
+                  align-items: stretch;
                   gap: 0.25rem;
                 }
                 .char-limit {
@@ -291,9 +292,10 @@
           }
           .project-directory {
             display: flex;
-            width: 38.625rem;
             align-items: center;
             gap: 0.5rem;
+            align-self: stretch;
+            align-items: stretch;
             .parent-folder {
               display: flex;
               width: 15rem;
@@ -304,7 +306,6 @@
             }
             .project-folder {
               display: flex;
-              width: 23.125rem;
               flex-direction: column;
               align-items: flex-start;
               gap: 0.25rem;

--- a/app/assets/stylesheets/requests.scss
+++ b/app/assets/stylesheets/requests.scss
@@ -56,7 +56,7 @@
 }
 
 .blue-box {
-  width: 75.1875rem;
+  align-self: stretch;
   padding: 1rem 1.5rem;
   align-items: center;
   border-radius: 0.75rem;


### PR DESCRIPTION
I wasn't able to make the wizard completely correct

## Before the blue-box change
<img width="1076" height="1013" alt="Screenshot 2025-12-12 at 10 07 38 AM" src="https://github.com/user-attachments/assets/b991ab7b-b63c-48c5-a2fa-820f378f3415" />

## after blue-box change
<img width="1070" height="1214" alt="Screenshot 2025-12-12 at 9 59 40 AM" src="https://github.com/user-attachments/assets/b31b891b-8873-4312-82e9-559e9db072a4" />

## before wizard changes
<img width="1074" height="1226" alt="Screenshot 2025-12-12 at 9 56 37 AM" src="https://github.com/user-attachments/assets/77cede9a-29a1-42a3-9826-0d993b0fb98c" />


## after wizard changes
<img width="1078" height="1222" alt="Screenshot 2025-12-12 at 9 57 01 AM" src="https://github.com/user-attachments/assets/94f262b8-1737-4e5c-8139-0a199260559c" />
