### PR TITLE
Rescue EOF errors at the system user level

### DIFF
--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -8,5 +8,24 @@ class SystemUser
       end
       logon_request.session_token
     end
+  rescue EOFError => ex
+    # Retry EOFErrors a few times
+    if eof_error_handler
+      Rails.logger.error "EOFError detected when attempting system logon. Details: #{ex.message}, retrying..."
+      Honeybadger.notify "EOFError detected when attempting system logon. Details: #{ex.message}, retrying..."
+      retry
+    else
+      raise Mediaflux::SessionError, "System logon failed due to repeated EOFErrors: #{ex.message}"
+    end
   end
+
+  private
+
+    def eof_error_handler
+      @retry_count ||= 0
+      @retry_count += 1
+      # TODO: How do we fix EOF errors?  Just retrying for now.
+
+      @retry_count < 3 # If the session is expired we should not have to retry more than once, but let's have a little wiggle room
+    end
 end


### PR DESCRIPTION
Most eof errors occur at the system user level when attempting a logon request. Try rescuing the eof failure at the logon request level