### PR TITLE
Style for the smallest devices

### DIFF
--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -351,6 +351,9 @@
         display: none;
         @media (max-width: 1279px) {
           display: flex;
+          justify-content: space-between;
+          align-items: center;
+          width: 100%;
         }
       }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,11 @@ body {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.625rem;
+
+    @media (max-width: 853px) {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
     @media (min-width: 854px) {
       padding-left: 1rem;
       padding-right: 1rem;


### PR DESCRIPTION
Got the styles for the smallest devices: which was the super narrow padding on the sides and making sure the activity (e.g. "Not Yet active") is flushed to the right.

<img width="498" height="788" alt="Screenshot 2026-01-05 at 2 18 04 PM" src="https://github.com/user-attachments/assets/9635dfb1-cc81-4df2-80ab-dd403b8bd875" />

Closes #2245 