### PR TITLE
Parent Project validation 

### DIFF
--- a/app/controllers/edit_requests_controller.rb
+++ b/app/controllers/edit_requests_controller.rb
@@ -15,7 +15,7 @@ class EditRequestsController < ApplicationController
   # PATCH/PUT /edit_requests/1 or /edit_requests/1.json
   def update
     respond_to do |format|
-      if @request_model.update(request_params) && @request_model.valid_to_submit?
+      if @request_model.update(request_params) && @request_model.valid_to_submit?(allow_empty_parent_folder: true)
         format.html { redirect_to request_url(@request_model), notice: I18n.t(:successful_update) }
         format.json { render :show, status: :ok, location: @request_model }
       else

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -39,7 +39,7 @@ class RequestsController < ApplicationController
   def approve
     if eligible_to_approve
       @request_model = Request.find(params[:id])
-      if @request_model.valid_to_submit?
+      if @request_model.valid_to_submit?(allow_empty_parent_folder: true)
         project = @request_model.approve(current_user)
         @request_model.destroy!
         stub_message = "The request has been approved and this project was created in the TigerData web portal.  The request has been processed and deleted."

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,7 +4,7 @@ class Request < ApplicationRecord
   DRAFT = "draft" # default state set by database
   SUBMITTED = "submitted" # Ready to be approved
 
-  def valid_to_submit?
+  def valid_to_submit?(allow_empty_parent_folder: false)
     errors.clear
     # run all validations and then check for errors otherwise ruby stops at the first error
     valid_title?
@@ -14,7 +14,7 @@ class Request < ApplicationRecord
     valid_quota?
     valid_project_purpose?
     valid_description?
-    valid_parent_folder?
+    valid_parent_folder?(allow_empty_parent_folder:)
     valid_project_folder?
     # For Skeletor we are setting the requestor to the data sponsor
     # valid_requested_by?
@@ -53,10 +53,10 @@ class Request < ApplicationRecord
     end
   end
 
-  def valid_parent_folder?
+  def valid_parent_folder?(allow_empty_parent_folder: false)
     check_errors? do
-      # the below-commented-out method may come back into use when this ticket is worked - https://github.com/pulibrary/tigerdata-app/issues/2219
-      field_present?(parent_folder, :parent_folder)
+      field_present?(parent_folder, :parent_folder) unless allow_empty_parent_folder
+      # Check the parent_folder for invalid characters.
       alphanumeric_dash_underscore_only(parent_folder, :parent_folder)
     end
   end
@@ -64,7 +64,7 @@ class Request < ApplicationRecord
   def valid_project_folder?
     check_errors? do
       field_present?(project_folder, :project_folder)
-      # Check the project folder for the error but only display the error under the parent folder
+      # Check the project folder for invalid characters (notice that we display the error under the parent folder)
       alphanumeric_dash_underscore_only(project_folder, :parent_folder)
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -240,9 +240,9 @@ RSpec.describe Request, type: :model do
 
   describe "#valid_parent_folder?" do
     it "requires a parent_folder" do
-      # the below-commented-out method may come back into use when this ticket is worked - https://github.com/pulibrary/tigerdata-app/issues/2219
-      # request = Request.new(parent_folder: "")
-      # expect(request.valid_parent_folder?).to be_falsey
+      request = Request.new(parent_folder: "")
+      expect(request.valid_parent_folder?).to be_falsey                                   # by default we don't allow empty parent folders
+      expect(request.valid_parent_folder?(allow_empty_parent_folder: true)).to be_truthy  # but we can allow it
       request = Request.new(parent_folder: "abc@")
       expect(request.valid_parent_folder?).to be_falsey
       request.parent_folder = "abc"

--- a/spec/system/new_project_request_wizard_spec.rb
+++ b/spec/system/new_project_request_wizard_spec.rb
@@ -323,9 +323,19 @@ describe "New Project Request page", type: :system, connect_to_mediaflux: false,
         within(".project-title") do
           expect(page).to have_content("This field is required.")
         end
+
         expect(page).to have_content("Please resolve errors before submitting your request")
         fill_in :project_title, with: "A basic Project"
         expect(page).to have_content "15/200 characters"
+
+        click_on("Submit")
+        within(".parent-folder") do
+          expect(page).to have_content("This field is required.")
+        end
+        within(".project-folder") do
+          expect(page).to have_content("This field is required.")
+        end
+
         fill_in :parent_folder, with: "abc_lab"
         fill_in :project_folder, with: "skeletor"
         select "Teaching", from: :project_purpose


### PR DESCRIPTION
Allow empty parent project folder in the request (but still require it in the Wizard)

Closes #2219 

