### PR TITLE
Adding checking for tester/trainer role on login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -180,6 +180,7 @@ class User < ApplicationRecord
     mediaflux_roles = mediaflux_roles(user:)
     update_developer_status(user:, mediaflux_roles:)
     update_sysadmin_status(user:, mediaflux_roles:)
+    update_tester_status(user:, mediaflux_roles:)
   rescue => ex
     Rails.logger.error("Error updating roles for user (id: #{user.id}) status, error: #{ex.message}")
   end
@@ -220,6 +221,16 @@ class User < ApplicationRecord
       # Only update the record in the database if there is a change
       Rails.logger.info("Updating sysadmin role for user #{user.id} to #{sysadmin_now}")
       user.sysadmin = sysadmin_now
+      user.save!
+    end
+  end
+
+  def self.update_tester_status(user:, mediaflux_roles:)
+    trainer_now = mediaflux_roles.include?("pu-lib:tester")
+    if user.trainer != trainer_now
+      # Only update the record in the database if there is a change
+      Rails.logger.info("Updating trainer role for user #{user.id} to #{trainer_now}")
+      user.trainer = trainer_now
       user.save!
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -120,16 +120,19 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
     before do
       sysadmin_user.developer = false
       sysadmin_user.sysadmin = false
+      sysadmin_user.trainer = true
       sysadmin_user.save!
     end
 
     it "mark as developer an admin and a developer user" do
       expect(sysadmin_user.sysadmin).to be false
       expect(sysadmin_user.developer).to be false
+      expect(sysadmin_user.trainer).to be true
       sign_in sysadmin_user
       User.update_user_roles(user: sysadmin_user)
       expect(sysadmin_user.sysadmin).to be true
       expect(sysadmin_user.developer).to be true
+      expect(sysadmin_user.trainer).to be false
     end
   end
 end


### PR DESCRIPTION
Gets the information from mediaflux, which gets the information from grouper

refs #1870