### PR TITLE
Display tigerdata-plugin version

### DIFF
--- a/app/controllers/mediaflux_info_controller.rb
+++ b/app/controllers/mediaflux_info_controller.rb
@@ -7,6 +7,7 @@ class MediafluxInfoController < ApplicationController
     @sysadmin = current_user.sysadmin
     @developer = current_user.developer
     @java_plugin_status = java_plugin_check
+    @java_plugin_version = java_plugin_version
     respond_to do |format|
       format.html
       format.json { render json: @mf_version }
@@ -22,6 +23,19 @@ class MediafluxInfoController < ApplicationController
     rescue => ex
       Rails.logger.error("Java plugin not working: #{ex.message}")
       "Not working: #{ex.message}"
+    end
+
+    def java_plugin_version
+      describe_request = Mediaflux::PackageDescribeRequest.new(package_name: "tigerdata-plugin", session_token: current_user.mediaflux_session)
+      describe_request.resolve
+      if describe_request.error?
+        "Not available (see log for details)"
+      else
+        describe_request.describe[:version]
+      end
+    rescue => ex
+      Rails.logger.error("Cannot determine version information for the Java plugin: #{ex.message}")
+      "Not available (see log for details)"
     end
 
     def mediaflux_version_info

--- a/app/models/mediaflux/package_describe_request.rb
+++ b/app/models/mediaflux/package_describe_request.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Mediaflux
+  class PackageDescribeRequest < Request
+    attr_reader :token, :service_name, :document
+
+    # Constructor
+    # @param session_token [String] the API token for the authenticated session
+    # @param package_name  [String] The name of the Mediaflux package to describe
+    def initialize(session_token:, package_name:)
+      super(session_token: session_token)
+      @package_name = package_name
+    end
+
+    # Specifies the Mediaflux service to use
+    # @return [String]
+    def self.service
+      "package.describe"
+    end
+
+    # Returns the quota information for collection in Mediaflux
+    def describe
+      result = response_xml.xpath("response/reply/result")
+      {
+        version: result.xpath("package/version").text,
+        description: result.xpath("package/version").text
+      }
+    end
+
+    private
+
+      def build_http_request_body(name:)
+        super do |xml|
+          xml.args do
+            xml.package @package_name
+          end
+        end
+      end
+  end
+end

--- a/app/views/mediaflux_info/index.html.erb
+++ b/app/views/mediaflux_info/index.html.erb
@@ -1,5 +1,8 @@
 <p>Connected to MediaFlux <b><%= @mf_version[:version] %></b> at <b><%= Mediaflux::Connection.host %></b>
 <dl>
+  <dt>tigerdata-plugin: </dt>
+  <dd><%= @java_plugin_version %></dd>
+
   <dt>Mediaflux Port: </dt>
   <dd><%= Mediaflux::Connection.port %></dd>
 

--- a/spec/models/mediaflux/package_version_request_spec.rb
+++ b/spec/models/mediaflux/package_version_request_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::PackageDescribeRequest, connect_to_mediaflux: true, type: :model do
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
+
+  describe "#describe" do
+    it "returns the version information" do
+      # A well-known existing package
+      request = described_class.new(session_token: user.mediaflux_session, package_name: "tigerdata-plugin")
+      expect(request.describe[:version] >= "0.0.2").to be true
+
+      # A non-existing existing package
+      request = described_class.new(session_token: user.mediaflux_session, package_name: "blah-blah-blah-tigerdata")
+      expect(request.describe[:version]).to eq ""
+    end
+  end
+end

--- a/spec/models/mediaflux/package_version_request_spec.rb
+++ b/spec/models/mediaflux/package_version_request_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Mediaflux::PackageDescribeRequest, connect_to_mediaflux: true, ty
     it "returns the version information" do
       # A well-known existing package
       request = described_class.new(session_token: user.mediaflux_session, package_name: "tigerdata-plugin")
+      expect(request.error?).to be false
       expect(request.describe[:version] >= "0.0.2").to be true
 
       # A non-existing existing package
       request = described_class.new(session_token: user.mediaflux_session, package_name: "blah-blah-blah-tigerdata")
+      expect(request.error?).to be true
       expect(request.describe[:version]).to eq ""
     end
   end


### PR DESCRIPTION
Display the tigerdata-plugin version information in the "Mediaflux info" page:

<img width="752" height="543" alt="Screenshot 2026-01-22 at 3 26 22 PM" src="https://github.com/user-attachments/assets/bc0bf639-6ff3-4014-8363-1d5671949daf" />
