### PR TITLE
Popover error

### DIFF
--- a/app/javascript/entrypoints/popoverManagement.js
+++ b/app/javascript/entrypoints/popoverManagement.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/prefer-default-export
 export function popoverManagement() {
   const popover = document.getElementById('confirm-delete-draft');
-  // if (popover === null) {
-  //   return;
-  // }
+  if (popover === null) {
+    return;
+  }
   if (popover.attributes.data.value === 'auto-load') popover.showPopover();
   const deleteElements = document.getElementsByClassName('delete-confirm');
 


### PR DESCRIPTION
Prevents a hidden JavaScript error that is being thrown when a page does not have the popover. The project pages don't have the element and were throwing a JavaScript error.

This PR adds a guard so that the code only executes when the `confirm-delete-draft` is found on the page.

<img width="1450" height="816" alt="Screenshot 2026-02-03 at 2 31 28 PM" src="https://github.com/user-attachments/assets/1a835d12-105c-4fcc-bcc5-e68dbe896b57" />
