### PR TITLE
Updates Faraday gem to recommended version due to security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,3 +133,6 @@ group :test do
 end
 
 gem "yard", "~> 0.9.36", group: :development
+
+# https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2
+gem "faraday", ">= 2.14.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,12 +200,12 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.13.4)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffaker (2.25.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm-linux-gnu)
@@ -300,8 +300,8 @@ GEM
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
     net-imap (0.5.10)
@@ -641,6 +641,7 @@ DEPENDENCIES
   dry-operation
   ed25519
   factory_bot_rails
+  faraday (>= 2.14.1)
   ffaker
   flipflop
   google-protobuf (~> 3.25)


### PR DESCRIPTION
Upgrades `faraday` gem to address security vulnerability recently reported.

This is what `bundler_audit` [reported in CircleCI:](https://app.circleci.com/pipelines/github/pulibrary/tigerdata-app/7008/workflows/f37c485f-aa36-403c-b811-feefb739f3a5/jobs/20178)

```
ruby-advisory-db:
  advisories:   1058 advisories
  last updated: 2026-02-11 11:24:37 -0800
  commit:       826ac198fe00af14343d839de644e74bf7d94d84
Name: faraday
Version: 2.13.4
CVE: CVE-2026-25765
GHSA: GHSA-33mh-2634-fwr2
Criticality: Medium
URL: https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2
Title: Faraday affected by SSRF via protocol-relative URL host override in build_exclusive_url
Solution: update to '>= 2.14.1'
```

