### PR TITLE
Add a modal to show the storage quota details

### DIFF
--- a/app/assets/stylesheets/_project.scss
+++ b/app/assets/stylesheets/_project.scss
@@ -488,3 +488,17 @@ blockquote {
     }
   } /* data-users-container */
 } /* data-users-section */
+
+.detail-storage-modal {
+  .modal-header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    gap: 0.5rem;
+
+    .modal-subtitle {
+      color: $gray-60;
+    }
+  }
+}

--- a/app/assets/stylesheets/_projects.scss
+++ b/app/assets/stylesheets/_projects.scss
@@ -125,6 +125,11 @@
     @include media-breakpoint-up(lg) {
       max-width: 75%;
     }
+
+    .quota-header {
+      display: flex;
+      justify-content: space-between;
+    }
   }
 }
 

--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -731,8 +731,9 @@
   align-items: center;
   gap: 2rem;
   border-radius: 0.5rem;
-  background: #fff;
+  background: $gray-extra-light;
   box-shadow: 0 10px 24px 0 rgba(25, 25, 25, 0.1);
+  border: $gray-10;
 }
 
 .pul-popover::backdrop {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -217,6 +217,12 @@ h6 {
   background: $red-darker;
 }
 
+.pul-button-link {
+  padding: 0px;
+  background: none;
+  border: none;
+}
+
 .info {
   display: flex;
   align-items: center;

--- a/app/views/projects/_project_details_heading.html.erb
+++ b/app/views/projects/_project_details_heading.html.erb
@@ -44,17 +44,22 @@
     <div class="col-lg-6">
       <div class="row">
         <div class="storage-quota container-fluid px-3 py-2 border border-secondary me-0">
-          <div class="row mt-2 mb-4">
-            <div class="col-6">
+          <div class="quota-header mt-2 mb-4">
+            <div>
               <b>Storage</b> <span class="storage-quota-total text-secondary">(<%= @presenter.formatted_storage_capacity(session_id: current_user.mediaflux_session) %> GB)</span>
             </div>
-            <div class="col-6 text-end">
-              <% if @presenter.can_increase_quota?(user: current_user) %>
-                <%= "Details" %>
+            <div>
+              <% if Flipflop.storage_details? %>
+                <input type="button" popovertarget="storage-details" value="Details" class="pul-button pul-button-link"></input>
+              <% else %>
+                <% if @presenter.can_increase_quota?(user: current_user) %>
+                  <%= link_to "Request More", "https://tigerdata.princeton.edu/form/quota-increase-request", target: "_blank", onclick: "log_plausible_request_more();" %>
+                <% end %>
               <% end %>
             </div>
           </div>
-          <div class="row my-2">
+          <%= render partial: "storage_details" %>
+          <div class="my-2">
             <div class="progress" role="progressbar" aria-label="Storage quota usage" aria-valuenow="<%= @presenter.formatted_quota_percentage(session_id: current_user.mediaflux_session) %>" aria-valuemin="0" aria-valuemax="100">
               <span class="progress-bar progress-bar-old-versions" title="Old versions: <%= @presenter.quota_breakdown[:old_versions_human] %>" style="width: <%= @presenter.quota_percentage_old_versions %>%"></span>
               <span class="progress-bar progress-bar-project-files" title="Project files: <%= @presenter.quota_breakdown[:project_files_human] %>" style="width: <%= @presenter.quota_percentage_files %>%"></span>

--- a/app/views/projects/_storage_details.html.erb
+++ b/app/views/projects/_storage_details.html.erb
@@ -1,0 +1,18 @@
+    <div popover="auto" id="storage-details"  class="pul-popover detail-storage-modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <div class="modal-title-frame"> 
+            <div class="model-title">Storage Usage Overview</div>
+            <input type=button popovertarget="storage-details" popovertargetaction="hide" class="pul-popover-close" data="cancel"></input>
+          </div>
+          <div class="modal-subtitle">
+           Detailed breakdown of your storage usage across different categories
+          </div>
+        </div>
+        <div>
+            <% if @presenter.can_increase_quota?(user: current_user) %>
+              <%= link_to "Request More", "https://tigerdata.princeton.edu/form/quota-increase-request", target: "_blank", onclick: "log_plausible_request_more();" %>
+            <% end %>
+        </div>
+      </div>
+    </div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -26,4 +26,5 @@ Flipflop.configure do
   feature :planned_maintenance, default: false, description: "Planned Maintenance. Disable login to the web portal."
   feature :last_updated_dashboard, default: false, description: "Show last updated column on dashboard."
   feature :project_type_indicator, default: false, description: "Show project type indicator on dashboard."
+  feature :storage_details, default: false, description: "Show project storage details"
 end

--- a/spec/system/project_details_spec.rb
+++ b/spec/system/project_details_spec.rb
@@ -18,6 +18,43 @@ RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true
       request.approve(sponsor_and_data_manager_user)
     end
 
+    context "details feature on" do
+      before do
+        test_strategy = Flipflop::FeatureSet.current.test!
+        test_strategy.switch!(:storage_details, true)
+      end
+
+      after do
+        test_strategy = Flipflop::FeatureSet.current.test!
+        test_strategy.switch!(:storage_details, false)
+      end
+
+      it "Shows the storage detail button to the sponsor" do
+        sign_in sponsor_user
+        visit "/projects/#{project_in_mediaflux.id}/details"
+        within ".storage-quota" do
+          click_on "Details"
+          expect(page).to have_content("Storage Usage Overview")
+          expect(page).to have_content("Request More")
+          click_on(class: "pul-popover-close")
+          expect(page).not_to have_content("Storage Usage Overview")
+        end
+      end
+
+      it "Shows the storage detail button to the data user" do
+        sign_in read_only
+        visit "/projects/#{project_in_mediaflux.id}/details"
+        within ".storage-quota" do
+          click_on "Details"
+          expect(page).to have_content("Storage Usage Overview")
+          expect(page).not_to have_content("Request More")
+          click_on(class: "pul-popover-close")
+          expect(page).not_to have_content("Storage Usage Overview")
+        end
+      end
+
+    end
+
     context "Navigation Buttons" do
       context "Approved projects" do
         context "Sponsor user" do
@@ -29,7 +66,7 @@ RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true
 
             expect(page).to have_content(project_in_mediaflux.title)
             expect(page).to have_content(project_in_mediaflux.project_directory)
-            expect(page).to have_content("Details")
+            expect(page).to have_content("Request More")
 
             # The description should be rendered twice (at the top and as part of the details)
             expect(page).to have_selector("#description-text")
@@ -59,6 +96,7 @@ RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true
             visit "/projects/#{project_in_mediaflux.id}/details"
             expect(page).to have_content(project_in_mediaflux.title)
             expect(page).to have_content(project_in_mediaflux.project_directory)
+            expect(page).not_to have_content("Request More")
           end
         end
 


### PR DESCRIPTION
Also adds a feature flipper to turn on and off the modal 
fixes #2388

## Feature flipper (off by default)
<img width="1695" height="513" alt="Screenshot 2026-02-13 at 11 27 44 AM" src="https://github.com/user-attachments/assets/8b2a14c7-f4ce-4aa3-82e9-2e1361fb4e43" />

## Request more when the feature is off
<img width="682" height="220" alt="Screenshot 2026-02-13 at 11 27 31 AM" src="https://github.com/user-attachments/assets/b3ef26a3-8202-46d0-ba7c-0ef4a80ea8dd" />


## Detail link when the feature is on
<img width="733" height="278" alt="Screenshot 2026-02-13 at 11 26 35 AM" src="https://github.com/user-attachments/assets/f0dc8d06-3651-4cdb-91b5-b5d62ed0dc22" />

## Modal
<img width="1735" height="545" alt="Screenshot 2026-02-13 at 11 28 08 AM" src="https://github.com/user-attachments/assets/40f1f657-270f-4942-8793-e2f9991e18cf" />
