### PR TITLE
Handle mediaflux errors better when updating user roles

### DIFF
--- a/app/operations/user_roles_update.rb
+++ b/app/operations/user_roles_update.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+class UserRolesUpdate < Dry::Operation
+
+  def call(user:)
+    step verify_session(user)
+    mediaflux_roles = step retrieve_roles_from_mediaflux(user)
+    step update_user_roles(user:, mediaflux_roles:)
+  end
+
+  private
+    def verify_session(user)
+      if user.mediaflux_session.nil?
+        Failure("UserRolesUpdate called with for a user without a Mediaflux session")
+      else
+        Success("valid!")
+      end
+    end
+
+    def retrieve_roles_from_mediaflux(user)
+      request = Mediaflux::ActorSelfDescribeRequest.new(session_token: user.mediaflux_session)
+      if request.error?
+        Failure("Error retrieving roles from Mediaflux: #{request.response_error}")
+      else
+        Success request.roles
+      end
+    end
+
+
+    def update_user_roles(user:, mediaflux_roles:)    
+      changed = update_developer_status(user:, mediaflux_roles:)
+      changed = update_sysadmin_status(user:, mediaflux_roles:) || changed
+      changed = update_tester_status(user:, mediaflux_roles:) || changed
+      if changed
+        user.save!
+      end
+      Success(user)
+    rescue StandardError => ex
+      Failure("Error updating user roles! error: #{ex}")
+    end
+
+
+    def update_tester_status(user:, mediaflux_roles:)
+      trainer_now = mediaflux_roles.include?("pu-smb-group:PU:tigerdata:tester-trainers") ||
+                    mediaflux_roles.include?("pu-oit-group:PU:tigerdata:tester-trainers")
+      if user.trainer != trainer_now
+        # Only update the record in the database if there is a change
+        Rails.logger.info("Updating trainer role for user #{user.id} to #{trainer_now}")
+        user.trainer = trainer_now
+        true
+      else
+        false
+      end
+    end
+
+    def update_sysadmin_status(user:, mediaflux_roles:)
+      sysadmin_now = mediaflux_roles.include?("system-administrator")
+      if user.sysadmin != sysadmin_now
+        # Only update the record in the database if there is a change
+        Rails.logger.info("Updating sysadmin role for user #{user.id} to #{sysadmin_now}")
+        user.sysadmin = sysadmin_now
+        true
+      else
+        false
+      end
+    end
+
+    def update_developer_status(user:, mediaflux_roles:)
+      # Production authentication has groups prefixed by "pu-smb-group". 
+      # In the future lower environments which currently have "pu-oit-group" should match production.
+      # See https://github.com/PrincetonUniversityLibrary/tigerdata-config/issues/289
+      #   production:            "pu-smb-group:PU:tigerdata:librarydevelopers"
+      #   staging & development: "pu-oit-group:PU:tigerdata:librarydevelopers"
+      #   test:                  "system-administrator"
+      developer_now = mediaflux_roles.include?("pu-smb-group:PU:tigerdata:librarydevelopers") ||
+        mediaflux_roles.include?("pu-oit-group:PU:tigerdata:librarydevelopers") ||
+        mediaflux_roles.include?("system-administrator")
+      if user.developer != developer_now
+        # Only update the record in the database if there is a change
+        Rails.logger.info("Updating developer role for user #{user.id} to #{developer_now}")
+        user.developer = developer_now
+        true
+      else
+        false
+      end
+    end
+
+end

--- a/spec/operations/user_roles_update_spec.rb
+++ b/spec/operations/user_roles_update_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe UserRolesUpdate, type: :operation, integration: true do
+  let!(:researcher) { FactoryBot.create(:user, uid: "libtigerdatadev", mediaflux_session: SystemUser.mediaflux_session) }
+  subject { described_class.new } # Or initialize with dependencies if any
+
+  describe "#call" do
+    context "Success case" do
+      it "updates a user's roles" do
+        result = described_class.new.call(user: researcher)
+        expect(result).to be_success
+        user = result.value!
+        # it gets the session information not based on the uid
+        expect(user.developer).to be_truthy
+        expect(user.sysadmin).to be_truthy
+        expect(user.trainer).to be_falsey
+      end
+
+      it "does not call save if it is not needed" do
+        # make sure the user matches with the mediaflux data
+        researcher.developer = true
+        researcher.sysadmin = true
+        researcher.created_at = "abc" # cause an exception if was called save
+        result = described_class.new.call(user: researcher)
+        expect(result).to be_success
+        user = result.value!
+        expect(user.developer).to be_truthy
+        expect(user.sysadmin).to be_truthy
+        expect(user.trainer).to be_falsey
+      end
+    end
+    context "Failure cases" do
+      it "returns a failure for user save errors" do
+        researcher.created_at = "abc" # case an exception on save
+        result = described_class.new.call(user: researcher)
+        expect(result).not_to be_success
+        error_message = result.failure
+        expect(error_message).to include("Error updating user roles! error: PG::NotNullViolation")
+        researcher.reload
+        expect(researcher.developer).to be_falsey
+        expect(researcher.sysadmin).to be_falsey
+        expect(researcher.trainer).to be_falsey
+      end
+
+      it "returns a failure for mediaflux session nil" do
+        researcher.mediaflux_session = nil
+        result = described_class.new.call(user: researcher)
+        expect(result).not_to be_success
+        error_message = result.failure
+        expect(error_message).to eq("UserRolesUpdate called with for a user without a Mediaflux session")
+        researcher.reload
+        expect(researcher.developer).to be_falsey
+        expect(researcher.sysadmin).to be_falsey
+        expect(researcher.trainer).to be_falsey
+      end
+
+      it "returns a failure for an invalid user" do
+        invalid_request = Mediaflux::ActorSelfDescribeRequest.new(session_token: "abc123")
+        allow(Mediaflux::ActorSelfDescribeRequest).to receive(:new).and_return(invalid_request)
+        allow(invalid_request).to receive(:error?).and_return(true)
+        allow(invalid_request).to receive(:response_error).and_return("ERROR")
+        result = described_class.new.call(user: researcher)
+        expect(result).not_to be_success
+        error_message = result.failure
+        expect(error_message).to eq("Error retrieving roles from Mediaflux: ERROR")
+        researcher.reload
+        expect(researcher.developer).to be_falsey
+        expect(researcher.sysadmin).to be_falsey
+        expect(researcher.trainer).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Do not set the role to blank if Mediaflux does not return a valid response