### PR TITLE
Fix Styles on project content pane

### DIFF
--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -94,14 +94,14 @@
 // put pages and totals on the same line
 .dataTables_info {
   float: left;
-  margin-top: 10px;
+  padding: 0.75rem;
 }
 
 // Put pagination on the far right
 .dataTables_paginate {
   float: right;
   display: inline-block;
-  margin-top: 10px;
+  padding: 0.75rem;
 
   .paginate_button {
     padding: 8px 16px;

--- a/app/assets/stylesheets/_project.scss
+++ b/app/assets/stylesheets/_project.scss
@@ -44,17 +44,31 @@
 }
 
 .contents-summary {
-  margin: 1rem 0px;
   padding: 0.75rem 1.5rem;
   background-color: $gray-10;
+  border-radius: 0.5rem;
+
+  // Note, this can not be a variable
+  --bs-border-color: #717171;
+}
+
+.project-pane {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  align-self: stretch;
+  align-items: stretch;
 
   .file-inventory {
     color: $gray-100;
     font-weight: 600;
   }
+}
 
-  // Note, this can not be a variable
-  --bs-border-color: #717171;
+.project-files {
+  border-radius: 0.5rem;
+  border: 1px solid $gray-20;
 }
 
 /* File Explorer Section */

--- a/app/views/projects/_contents.html.erb
+++ b/app/views/projects/_contents.html.erb
@@ -1,5 +1,5 @@
-<div class="content-info"><i class="bi bi-info-circle"></i>Showing the first 100 files due to preview limit.</div>
 <div class="table project-files">
+   <div class="content-info"><i class="bi bi-info-circle"></i>Showing the first 100 files due to preview limit.</div>
    <table id="project-contents" >
    <thead>
       <tr class="content heading">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -2,6 +2,7 @@
 
 <content id= "content">
   <div class="container-fluid">
+  <div class="project-pane">
     <div id="project-nav">
       <button id="project-content" class="tab-nav"> Content Preview </button>
       <button id="project-details" class="tab-nav"> Details </button>
@@ -11,8 +12,8 @@
       <div class="col-sm-2 file-total-label">Total Files: <%= ActiveSupport::NumberHelper.number_to_delimited(@num_files) %></div>
       <div class="col-sm-8 text-end divider">
         <div name="project-contents-preview">
-          <button class="btn btn-secondary" popovertarget="list-contents-modal">Download Complete List</button>
-        </form>
+          <button class="btn pul-button-primary" popovertarget="list-contents-modal">Download Complete List</button>
+        </div>
       </div>
     </div>
 
@@ -28,9 +29,9 @@
         </div>
       </div>
     </section>
-  </content>
-
-</div>
+  </div>
+  </div>
+</content>
 
 <div popover="auto" id="list-contents-modal" class="pul-popover">
   <div class="modal-content">


### PR DESCRIPTION
Close Divs correctly and in the correct order
Apply additional styles to match figma

fixes #2363

<img width="1319" height="571" alt="Screenshot 2026-02-20 at 11 19 49 AM" src="https://github.com/user-attachments/assets/d3986c07-5b2c-4bb5-befc-e70e2bd2a209" />
