### PR TITLE
Fix storage usage overview modal display bug

### DIFF
--- a/app/assets/stylesheets/_projects.scss
+++ b/app/assets/stylesheets/_projects.scss
@@ -302,9 +302,13 @@
       color: $gray-60;
     }
   }
+  .detailed-quota-subtypes-container {
+    display: flex;
+  }
   .detailed-quota-subtypes-free-space {
-    display: ruby;
-    margin-left: 8rem;
+    display: flex;
+    margin-left: auto;
+    gap: 0.5rem;
     .subtype-size-free-space {
       color: $gray-60;
       font-size: 0.875rem;


### PR DESCRIPTION
ref #2464 

bug:
<img width="959" height="609" alt="Screenshot 2026-03-10 at 9 12 49 AM" src="https://github.com/user-attachments/assets/7e1a29c5-c7b6-4709-b95a-2745a2e2a792" />
<img width="1287" height="845" alt="Screenshot 2026-03-10 at 12 08 49 PM" src="https://github.com/user-attachments/assets/8608fad7-35ae-4763-b1d7-da421718215e" />


fixes display bug pushing the `free space` div to a new line with large storage subtype values
<img width="959" height="590" alt="Screenshot 2026-03-10 at 5 00 12 PM" src="https://github.com/user-attachments/assets/15b12bfe-cd6c-41e1-a507-2838430c4aa9" />
