### PR TITLE
Upgrading version of Node.js for GitHub actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
+
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
We're getting some warnings in Dependabot like so:

```
[Complete job](https://github.com/pulibrary/tigerdata-app/actions/runs/23065581069/job/67002944298#annotation:7:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: github/dependabot-action@main. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

I *think* this might address that.