### PR TITLE
Updating styling to match figma more exactly

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -40,7 +40,7 @@
   }
   .main-frame {
     display: flex;
-    height: 45.6875rem;
+    height: 51.25rem;
     align-items: flex-start;
     gap: 1.25rem;
     align-self: stretch;
@@ -836,69 +836,54 @@
   }
 }
 
-.sidebar-width {
-  width: 17.8125rem;
-}
-
-/* NOTE - Values within the New Project Wizard sidebar need to be measured in pixels to maintain the layout */
-
 #new-project-wizard-sidebar {
-  width: 100%;
-  height: 100%;
-  padding-left: 20px;
-  padding-right: 20px;
-  padding-top: 24px;
-  padding-bottom: 24px;
-  background: $gray-5;
-  overflow: hidden;
-  border-radius: 12px;
+  display: flex;
+  width: 17.8125rem;
+  padding: 1.5rem 1.25rem;
   justify-content: center;
   align-items: flex-start;
-  display: inline-flex;
+  border-radius: 0.75rem;
+  background: $gray-5;
 }
 
 .sidebar-container {
-  flex: 1 1 0;
-  overflow: hidden;
+  display: flex;
   flex-direction: column;
-  justify-content: flex-start;
   align-items: flex-start;
-  gap: 20px;
-  display: inline-flex;
+  gap: 1.25rem;
+  flex: 1 0 0;
 }
 
 .expanded-state {
-  align-self: stretch;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 20px;
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  align-self: stretch;
 }
 
 .unexpanded-state {
-  align-self: stretch;
-  height: 28px;
-  justify-content: flex-start;
+  display: flex;
+  height: 1.75rem;
   align-items: center;
-  gap: 12px;
-  display: inline-flex;
+  gap: 0.75rem;
+  align-self: stretch;
 }
 
 .step-container {
-  justify-content: flex-start;
-  align-items: center;
-  gap: 12px;
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  align-self: stretch;
 }
 
 .step {
-  width: 217px;
-  height: 28px;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 12px;
   display: flex;
+  width: 13.5625rem;
+  height: 1.75rem;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .step-number-completed {
@@ -945,19 +930,21 @@
 }
 
 .step-text-container {
-  justify-content: flex-start;
-  align-items: flex-start;
   display: flex;
+  align-items: flex-start;
 }
 
 .step-text,
 .step-text a:link,
 .step-text a:visited {
   color: $black;
-  font-size: 14px;
+
+  /* Body XXS Bold */
   font-family: $libre-franklin;
+  font-size: 0.75rem;
+  font-style: normal;
   font-weight: 600;
-  line-height: 21px;
+  line-height: 1.125rem; /* 150% */
   word-wrap: break-word;
   text-decoration: none;
 }
@@ -989,13 +976,11 @@
 }
 
 .substeps-container {
-  width: 217px;
-  position: relative;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 20px;
   display: flex;
+  width: 13.5625rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
 }
 
 .connector-line {
@@ -1011,51 +996,43 @@
 }
 
 .substep-container {
-  width: 217px;
-  height: 20px;
-  padding-left: 40px;
-  justify-content: flex-start;
+  display: flex;
+  width: 13.5625rem;
+  height: 1.25rem;
+  padding-left: 2.5rem;
   align-items: center;
-  gap: 12px;
-  display: inline-flex;
+  gap: 0.75rem;
 }
 
 .substep-indicator-container {
-  width: 20px;
-  height: 20px;
-  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
 }
 
 .substep-indicator-completed {
-  width: 20px;
-  height: 20px;
-  left: 0px;
-  top: 0px;
-  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
   background: $princeton-orange-80;
-  border-radius: 9999px;
+  border-radius: 2rem;
 }
 
 .substep-indicator-current {
-  display: flex;
-  width: 20px;
-  height: 20px;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  border-radius: 14px;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  border-radius: 2rem;
   border: 2px solid $princeton-orange-80;
   background: $white;
 }
 
 .substep-indicator-incomplete {
-  width: 20px;
-  height: 20px;
-  left: 0px;
-  top: 0px;
-  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
   background: $gray-20;
-  border-radius: 9999px;
+  border-radius: 2rem;
 }
 
 .substep-text,

--- a/app/assets/stylesheets/components/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/breadcrumbs.scss
@@ -1,7 +1,9 @@
 .breadcrumbs {
   list-style-type: none;
   padding: 0px;
-  margin: 2em 0em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 
   a {
     color: $black;

--- a/app/views/new_project_wizard/_sidebar.html.erb
+++ b/app/views/new_project_wizard/_sidebar.html.erb
@@ -1,4 +1,3 @@
-<div class="sidebar-width">
 <div id="new-project-wizard-sidebar">
     <div class="sidebar-container">
         <div data-state="Expanded" class="expanded-state">
@@ -51,5 +50,4 @@
                                                                     step_number: 4, step_url: new_project_review_and_submit_path(@new_project_request), step_name: 'Review and Submit'} %>
 
     </div>
-</div>
 </div>

--- a/app/views/new_project_wizard/_sidebar_multi_step.html.erb
+++ b/app/views/new_project_wizard/_sidebar_multi_step.html.erb
@@ -7,7 +7,7 @@
             <div class="step-text"><a class="go-to-step" href="<%= step_url %>"><%= step_name %></a></div>
         </div>
     </div>
-    <!-- don't render the care for now since we are not using it -->
+    <!-- don't render the caret for now since we are not using it -->
     <% if false %>
         <div class="step-expanded-container">
             <div class="step-expanded"></div>

--- a/app/views/new_project_wizard/_sidebar_multi_step_optional.html.erb
+++ b/app/views/new_project_wizard/_sidebar_multi_step_optional.html.erb
@@ -7,7 +7,7 @@
             <div class="step-text"><a class="go-to-step" href="<%= step_url %>"><%= step_name %></a><span class="substep-text">(Optional)</span></div>
         </div>
     </div>
-    <!-- don't render the care for now since we are not using it -->
+    <!-- don't render the caret for now since we are not using it -->
     <% if false %>
         <div class="step-expanded-container">
             <div class="step-expanded"></div>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -9,11 +9,10 @@
           <%= crumb.name %>
         </span>
       <% end %>
-
-      <% unless crumb == breadcrumbs.last %>
-        <span class="breadcrumb-separator">></span>
-      <% end %>
      </li>
+     <% unless crumb == breadcrumbs.last %>
+       <li aria-hidden="true">></li>
+     <% end %>
     <% end %>
   </ul>
 </nav>


### PR DESCRIPTION
remove pixel sizes
use flex instead of position

## Current wizard

<img width="567" height="619" alt="Screenshot 2026-03-18 at 8 40 06 AM" src="https://github.com/user-attachments/assets/fbb1db84-eb43-47ec-b1d7-976b1cf628f3" />

## Figma
<img width="511" height="488" alt="Screenshot 2026-03-18 at 8 41 50 AM" src="https://github.com/user-attachments/assets/0f67634b-3c75-4739-8a60-0fe78f947062" />

## New Code
<img width="558" height="642" alt="Screenshot 2026-03-18 at 8 40 33 AM" src="https://github.com/user-attachments/assets/eddab387-6335-4327-884c-33d0da5b1751" />
