### PR TITLE
Make wizard layout responsive to smaller screens

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -8,6 +8,12 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2.5rem;
+
+  @media (max-width: 1280px) {
+    padding: 1.5rem 1.25rem;
+    gap: 1.44rem;
+  }
+
   nav {
     display: flex;
     height: 1.8125rem;
@@ -17,6 +23,16 @@
     @media (min-width: 1440px) {
       width: 75rem;
     }
+    @media (max-width: 1280px) {
+      padding: 0.25rem 1.25rem;
+      align-items: center;
+      gap: 0.625rem;
+    }
+    .breadcrumbs {
+      @media (max-width: 1280px) {
+        margin-bottom: 0rem;
+      }
+    }
   }
   .heading-frame {
     display: flex;
@@ -25,6 +41,9 @@
     gap: 0.25rem;
     @media (min-width: 1440px) {
       width: 75rem;
+    }
+    @media (max-width: 1280px) {
+      padding: 0rem 1.25rem 1.3rem 1.25rem;
     }
 
     .heading-text {
@@ -54,6 +73,12 @@
       width: 75rem;
     }
 
+    @media (max-width: 1280px) {
+      padding: 0 1.25rem;
+      gap: 2.875rem;
+      display: flex;
+    }
+
     .form-panel {
       display: flex;
       flex-direction: column;
@@ -72,6 +97,9 @@
         gap: 2.5rem;
         align-self: stretch;
 
+        @media (max-width: 1280px) {
+          gap: 1.4375rem;
+        }
         .form-header {
           display: flex;
           padding: 0.75rem 0rem 1.5rem 0rem;
@@ -81,6 +109,11 @@
           align-self: stretch;
           border-bottom: 1px solid $gray-20;
           background: $white;
+
+          @media (max-width: 1280px) {
+            padding: 0rem;
+            padding-bottom: 1.5rem;
+          }
 
           .form-title {
             display: flex;
@@ -190,6 +223,10 @@
         align-self: stretch;
         width: 100%;
 
+        @media (max-width: 930px) {
+          flex-direction: column;
+        }
+
         .field-info {
           display: flex;
           width: 11.4375rem;
@@ -244,6 +281,11 @@
           padding-right: 10px;
           gap: 0.5rem;
           flex: 1 0 0;
+
+          @media (max-width: 1280px) {
+            padding-right: 0px;
+          }
+
           .text-input {
             display: flex;
             flex-direction: column;
@@ -882,6 +924,10 @@
   align-items: flex-start;
   border-radius: 0.75rem;
   background: $gray-5;
+  @media (max-width: 1280px) {
+    width: 14.8125rem;
+    flex-shrink: 0;
+  }
 }
 
 .sidebar-container {
@@ -890,6 +936,9 @@
   align-items: flex-start;
   gap: 1.25rem;
   flex: 1 0 0;
+  @media (max-width: 1280px) {
+    width: 12.625rem;
+  }
 }
 
 .expanded-state {

--- a/app/views/new_project_wizard/_form_project_storage.html.erb
+++ b/app/views/new_project_wizard/_form_project_storage.html.erb
@@ -82,6 +82,7 @@
     </div>
 </div>
 
+<!-- TODO: causes overflow under 930px -->
 <div class="form-field">
     <%= render partial: "/new_project_wizard/form_field_label",
     locals: {field_label: "Connection Options", field_sub_label: "Required"} %>

--- a/app/views/new_project_wizard/_review_and_submit_form.html.erb
+++ b/app/views/new_project_wizard/_review_and_submit_form.html.erb
@@ -22,6 +22,7 @@
                locals: {data_sponsor: @new_project_request.data_sponsor || "", data_sponsor_name: @new_project_request.data_sponsor_name, data_sponsor_error: @new_project_request.errors[:data_sponsor].join(", ") } %>
     <%= render partial: "/new_project_wizard/form_data_manager_input",
                locals: {data_manager: @new_project_request.data_manager || "", data_manager_name: @new_project_request.data_manager_name, data_manager_error: @new_project_request.errors[:data_manager].join(", ") } %>
+    <!-- TODO: causes overflow under 930px -->
     <%= render partial: "/new_project_wizard/form_user_roles_input", locals: {user_roles: @new_project_request.user_roles || [], user_roles_error: @new_project_request.errors[:user_roles].join(", ") } %>
 </div>
 <div class="section-line"></div>


### PR DESCRIPTION
Start Shrinking margins at 1024px and stack labels at 930px 

Chose 930px because the screen adds a scroll bar at 930px without the stacking the labels. (See TODO)

refs #2476

## ipad mini
<img width="699" height="854" alt="Screenshot 2026-03-20 at 12 00 00 PM" src="https://github.com/user-attachments/assets/3ad44d0d-3e71-40f8-9fd6-45e4ddb2385a" />

## ipad air
<img width="719" height="1088" alt="Screenshot 2026-03-20 at 11 59 50 AM" src="https://github.com/user-attachments/assets/ae06dc16-e8ea-48f8-b535-3e0a364ec5b6" />

## ipad pro
<img width="666" height="776" alt="Screenshot 2026-03-20 at 11 59 37 AM" src="https://github.com/user-attachments/assets/e9293d28-b0e0-4426-983f-0543426901d5" />
