### PR TITLE
Updating the user modal to size with the wizard

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -535,7 +535,7 @@
             }
 
             .user-cell.cell {
-              width: 18.75rem;
+              flex-grow: 2;
             }
 
             .cell {
@@ -602,6 +602,10 @@
             pointer-events: none;
             position: absolute;
           }
+        }
+        .user-role.pul-popover {
+          width: 80%;
+          background: $white;
         }
       }
 
@@ -1167,25 +1171,29 @@
 }
 
 /* Tooltip text */
-.pul-tooltiptext-left::after {
+.pul-tooltiptext::after {
   content: " ";
   position: absolute;
   top: 2.25rem;
-  right: 100%; /* To the left of the tooltip */
   margin-top: -5px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent #333 transparent transparent;
+}
+
+.pul-tooltiptext-left::after {
+  @media (min-width: 931px) {
+    right: 100%; /* To the left of the tooltip */
+    border-color: transparent #333 transparent transparent;
+  }
+  /* once the screen is small force the tooltip left where we know we have room */
+  @media (max-width: 930px) {
+    left: 100%; /* To the right of the tooltip */
+    border-color: transparent transparent transparent #333;
+  }
 }
 
 .pul-tooltiptext-right::after {
-  content: " ";
-  position: absolute;
-  top: 2.25rem;
-  left: 100%; /* To the left of the tooltip */
-  margin-top: -5px;
-  border-width: 5px;
-  border-style: solid;
+  left: 100%; /* To the right of the tooltip */
   border-color: transparent transparent transparent #333;
 }
 
@@ -1211,7 +1219,12 @@
 }
 
 .pul-tooltiptext-left {
-  left: 105%;
+  @media (min-width: 931px) {
+    right: 105%;
+  }
+  @media (max-width: 930px) {
+    right: 105%;
+  }
 }
 
 .pul-tooltiptext-right {

--- a/app/views/new_project_wizard/_form_project_storage.html.erb
+++ b/app/views/new_project_wizard/_form_project_storage.html.erb
@@ -82,7 +82,6 @@
     </div>
 </div>
 
-<!-- TODO: causes overflow under 930px -->
 <div class="form-field">
     <%= render partial: "/new_project_wizard/form_field_label",
     locals: {field_label: "Connection Options", field_sub_label: "Required"} %>

--- a/app/views/new_project_wizard/_review_and_submit_form.html.erb
+++ b/app/views/new_project_wizard/_review_and_submit_form.html.erb
@@ -22,7 +22,6 @@
                locals: {data_sponsor: @new_project_request.data_sponsor || "", data_sponsor_name: @new_project_request.data_sponsor_name, data_sponsor_error: @new_project_request.errors[:data_sponsor].join(", ") } %>
     <%= render partial: "/new_project_wizard/form_data_manager_input",
                locals: {data_manager: @new_project_request.data_manager || "", data_manager_name: @new_project_request.data_manager_name, data_manager_error: @new_project_request.errors[:data_manager].join(", ") } %>
-    <!-- TODO: causes overflow under 930px -->
     <%= render partial: "/new_project_wizard/form_user_roles_input", locals: {user_roles: @new_project_request.user_roles || [], user_roles_error: @new_project_request.errors[:user_roles].join(", ") } %>
 </div>
 <div class="section-line"></div>


### PR DESCRIPTION
Make the user table more stable for the name width fixes #2476
Move the tooltip to the other side when the screen gets small

## user popover/Modal in Main
<img width="770" height="1153" alt="Screenshot 2026-03-20 at 3 40 23 PM" src="https://github.com/user-attachments/assets/a29594cd-c49e-4c4c-956f-747e81dc4f9f" />

## user popover/modal with update
<img width="765" height="1146" alt="Screenshot 2026-03-20 at 3 40 51 PM" src="https://github.com/user-attachments/assets/9bdb2c79-24e6-4e8c-b84d-f6effc4cd78f" />

## User table in main
<img width="491" height="474" alt="Screenshot 2026-03-20 at 3 40 32 PM" src="https://github.com/user-attachments/assets/985d5051-1d9c-42ea-b95c-8b98407636e3" />

## User table in update

<img width="534" height="376" alt="Screenshot 2026-03-20 at 3 43 32 PM" src="https://github.com/user-attachments/assets/4d544680-7c30-4be2-ad51-4503a9a45c2e" />

## Tooltip on main
<img width="337" height="282" alt="Screenshot 2026-03-20 at 3 51 54 PM" src="https://github.com/user-attachments/assets/d57120d6-f143-42d8-9fb1-997423aab003" />

## Tooltip on branch
<img width="506" height="271" alt="Screenshot 2026-03-20 at 3 52 21 PM" src="https://github.com/user-attachments/assets/213c0163-dd5f-4b23-9d4c-07a2235c9eab" />
