### PR TITLE
Updating the wizard for wide screens

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -9,6 +9,9 @@
   align-items: flex-start;
   gap: 2.5rem;
 
+  @media (min-width: 1440px) {
+    align-items: center;
+  }
   @media (max-width: 1280px) {
     padding: 1.5rem 1.25rem;
     gap: 1.44rem;
@@ -71,6 +74,7 @@
     overflow: auto;
     @media (min-width: 1440px) {
       width: 75rem;
+      align-self: center;
     }
 
     @media (max-width: 1280px) {
@@ -606,6 +610,9 @@
         .user-role.pul-popover {
           width: 80%;
           background: $white;
+          @media (min-width: 1250px) {
+            width: 800px;
+          }
         }
       }
 


### PR DESCRIPTION
fixes #2474

## Screen on main is left
<img width="1817" height="963" alt="Screenshot 2026-03-24 at 2 47 33 PM" src="https://github.com/user-attachments/assets/2bb17041-04ca-430f-8dc9-19aa23b61768" />

## Screen on branch is centered
<img width="1872" height="1024" alt="Screenshot 2026-03-24 at 2 31 31 PM" src="https://github.com/user-attachments/assets/f049621a-48ca-45e1-91e2-99f6bf87c3a0" />

## Modal on main is really large
<img width="1876" height="1128" alt="Screenshot 2026-03-24 at 2 47 43 PM" src="https://github.com/user-attachments/assets/aab68f2a-7d11-410f-b8fe-edb4f73dc43d" />

## Modal on branch maxes out
<img width="1859" height="1130" alt="Screenshot 2026-03-24 at 2 31 43 PM" src="https://github.com/user-attachments/assets/f2c3f37a-499a-4db4-9082-ba8607b91e23" />
