### PR TITLE
Adding a rake task to reload test project under a certain path

### DIFF
--- a/app/services/test_project_cleaner.rb
+++ b/app/services/test_project_cleaner.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class TestProjectCleaner
+  def initialize(path = "/princeton/tigerdata/RDSS/")
+    @path = path
+  end
+
+  def clean
+    test_projects = Project.where("metadata_json->> 'project_directory' like ?", "#{@path}%") # Implementation for cleaning project at @path
+    test_projects.map(&:destroy)
+  end
+
+  def reload
+    clean
+    ProjectImport.run_with_report(mediaflux_session: SystemUser.mediaflux_session).sort
+  end
+end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -88,6 +88,15 @@ namespace :projects do
     end
   end
 
+  desc "rebuild test project under a certain path. Imports all projects from Mediaflux"
+  task :rebuild_test_projects, [:path] => [:environment] do |_, args|
+    path = args[:path] # default path is /princeton/tigerdata/RDSS/ 
+    time_action("Creating projects") do
+      cleaner = TestProjectCleaner.new(path)
+      puts cleaner.reload
+    end
+  end
+
   def time_action(label)
     start_time = Time.current.in_time_zone("America/New_York").iso8601
     yield

--- a/spec/services/test_project_cleaner_spec.rb
+++ b/spec/services/test_project_cleaner_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe TestProjectCleaner, type: :service do
+  let!(:project_a) { test_project_from_path("/princeton/tigerdata/RDSS/Query/AProject") }
+  let!(:project_b) { test_project_from_path("/princeton/tigerdata/RDSS/Query/BProject") }
+  let!(:other_project) { create_project_in_mediaflux }
+  let(:cleaner) { TestProjectCleaner.new }
+
+  describe "#clean" do
+    it "removes test projects, but leaves other projects" do
+      expect(Project.count).to eq(3)
+      expect do
+        cleaner.clean
+      end.to change { Project.count }.from(3).to(1)
+    end
+  end
+
+  describe "#reload" do
+    it "creates a new project with the attributes from mediaflux" do
+      cleaner.reload
+      new_project_a = Project.find_by(mediaflux_id: project_a.mediaflux_id)
+      expect(new_project_a).not_to be_nil
+      expect(new_project_a.id).not_to eq(project_a.id)
+      expect(new_project_a.title).to eq(project_a.title)
+      new_project_b = Project.find_by(mediaflux_id: project_b.mediaflux_id)
+      expect(new_project_b).not_to be_nil
+      expect(new_project_b.id).not_to eq(project_b.id)
+      expect(new_project_b.title).to eq(project_b.title)
+    end
+  end
+end

--- a/spec/support/project_in_mediaflux.rb
+++ b/spec/support/project_in_mediaflux.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 def create_project_in_mediaflux(request: nil, current_user: nil)
   request ||= FactoryBot.create(:request_project)
-  current_user ||= FactoryBot.create(:sysadmin, uid: "tigerdatatester")
-  tigerdatatester = User.where(uid: "tigerdatatester").first
-  if tigerdatatester.blank?
-    FactoryBot.create(:user, uid: "tigerdatatester")
-  end
+  tigerdatatester = User.where(uid: "tigerdatatester").first || FactoryBot.create(:user, uid: "tigerdatatester", mediaflux_session: SystemUser.mediaflux_session  )
+  current_user ||= tigerdatatester
+  current_user.mediaflux_session ||= SystemUser.mediaflux_session
   project = request.approve(current_user)
   request.destroy!
   project
@@ -15,9 +13,15 @@ end
 def test_project_from_path(path)
   metadata = Mediaflux::AssetMetadataRequest.new(session_token: SystemUser.mediaflux_session, id: "path=#{path}").metadata
   id = metadata[:id]
+  raise StandardError, "Project not found in Mediaflux #{path}" if id.nil?
   data_sponsor = metadata[:data_sponsor]
   data_manager = metadata[:data_manager]
+  data_users = metadata[:data_users]
   FactoryBot.create(:user, uid: data_sponsor) unless User.where(uid: data_sponsor).exists?
   FactoryBot.create(:user, uid: data_manager) unless User.where(uid: data_manager).exists?
-  FactoryBot.create(:project, mediaflux_id: id, data_sponsor:, data_manager: )
+  data_users = metadata[:data_users]
+  data_users.each do |user_uid|
+    FactoryBot.create(:user, uid: user_uid) unless User.where(uid: user_uid).exists?
+  end
+  FactoryBot.create(:project, mediaflux_id: id, data_sponsor:, data_manager:, project_directory: path, title: metadata[:title])
 end


### PR DESCRIPTION
refs #2581

Can be run with either no path `rake projects:rebuild_test_projects` 
or with a path `rake projects:rebuild_test_projects\["/princeton/tigerdata/RDSS/Query"]`