### PR TITLE
Refine integration suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,9 +304,8 @@ workflows:
   version: 2
   build_accept_deploy:
     when:
-      or:
-        - equal: ["<< pipeline.parameters.GHA_Event >>", ""]
-        - equal: ["<< pipeline.parameters.GHA_Meta >>", "TigerData-Config"] # WIP: This workflow can/(will be able to) be triggered by deploys to the mediaflux CI server
+      equal: ["<< pipeline.parameters.GHA_Event >>", ""]
+
     jobs:
       - bundler_lint
       - bundler_audit
@@ -333,3 +332,9 @@ workflows:
             branches:
               only:
                 - main
+
+  integration_tests:
+    when:
+      equal: ["<< pipeline.parameters.GHA_Meta >>", "TigerData-Config"] # This workflow is triggered by deploys to the mediaflux CI server
+    jobs:
+      - mflux_ci


### PR DESCRIPTION
we only need the integration tests (`mflux_ci` job) to run when tigerdata-config is deployed to `mflux-ci1`. This will speed up our test suite since we are only running one job in our integration suite. (Merging to main in tigerdata-app will still trigger the entire test suite including mflux_ci like normal)