### PR TITLE
Moving svg into a vue component.

### DIFF
--- a/app/javascript/vue_components/exclamation_triangle.vue
+++ b/app/javascript/vue_components/exclamation_triangle.vue
@@ -1,0 +1,32 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    :fill="fillColor"
+    class="bi bi-exclamation-triangle-fill"
+    viewBox="0 0 16 16"
+  >
+    <path
+      d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"
+    />
+  </svg>
+</template>
+<script setup>
+import { ref } from 'vue';
+
+defineOptions({ name: 'ExclamationTriangle' });
+const props = defineProps({
+  /**
+   * The color of the triagnle.
+   * An array of objects with a name, path and collection indicator, size and last modified date.
+   */
+  color: {
+    type: String,
+    required: false,
+    default: 'currentColor',
+  },
+});
+
+const fillColor = ref(props.color);
+</script>

--- a/app/javascript/vue_components/file_browser.vue
+++ b/app/javascript/vue_components/file_browser.vue
@@ -23,18 +23,7 @@
     >
       <div class="row">
         <div class="col-auto mx-3 my-1">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            fill="currentColor"
-            class="bi bi-exclamation-triangle-fill"
-            viewBox="0 0 16 16"
-          >
-            <path
-              d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"
-            />
-          </svg>
+          <exclamation-triangle color="#FBC129"></exclamation-triangle>
         </div>
         <div class="col mx-3">
           <header>Preview Limit Reached</header>
@@ -98,6 +87,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import CopyPath from './copy_path.vue';
+import ExclamationTriangle from './exclamation_triangle.vue';
 import { ProjectComponent } from '../components/Project.ts';
 
 defineOptions({ name: 'FileBrowser' });


### PR DESCRIPTION
Cleans up the File Browser template and allows for the icon to be re-used

Changes the color of the icon to match figma and extracts it so it is not inline in the file browser.

## Original Screen
<img width="1074" height="129" alt="Screenshot 2026-04-28 at 2 01 11 PM" src="https://github.com/user-attachments/assets/166b9d7b-a415-4b61-a7a8-482a7c373c4c" />

## Figma display
<img width="1495" height="157" alt="Screenshot 2026-04-28 at 2 01 05 PM" src="https://github.com/user-attachments/assets/c9b06189-23f6-447b-b56c-33fc29a79c0d" />

## New Screen
<img width="1117" height="142" alt="Screenshot 2026-04-28 at 2 00 09 PM" src="https://github.com/user-attachments/assets/a50f16a2-25d7-4907-b39a-1a6f9184b71e" />
