### PR TITLE
Making folder details different than file details

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -25,8 +25,6 @@ import { Modal } from 'bootstrap';
 // Import Vue Components
 import FileBrowser from '../vue_components/file_browser.vue';
 import CopyPath from '../vue_components/copy_path.vue';
-// Import JS Components
-import Project from '../vue_components/project.vue';
 
 // ActionCable Channels
 import '../channels/index.js';
@@ -90,7 +88,6 @@ document.addEventListener('DOMContentLoaded', () => {
       .component('lux-date-picker', LuxDatePicker)
       .component('file-browser', FileBrowser)
       .component('copy-path', CopyPath)
-      .component('project', Project)
       .mount(elements[i]);
   }
 });

--- a/app/javascript/vue_components/file_browser.vue
+++ b/app/javascript/vue_components/file_browser.vue
@@ -69,7 +69,7 @@
           </table>
         </div>
       </div>
-      <project :current-object="currentObject" />
+      <project-item :current-object="currentObject" />
     </div>
   </div>
 </template>
@@ -77,9 +77,8 @@
 import { ref, onMounted } from 'vue';
 import CopyPath from './copy_path.vue';
 import ExclamationTriangle from './exclamation_triangle.vue';
-import { ProjectComponent } from '../components/Project.ts';
 import HomeIcon from './home_icon.vue';
-import Project from './project.vue';
+import ProjectItem from './project_item.vue';
 
 defineOptions({ name: 'FileBrowser' });
 const props = defineProps({
@@ -147,7 +146,6 @@ function clearCurrent(file) {
   return file;
 }
 async function onClickRow(file) {
-  await ProjectComponent.dispatchProjectStateChange(file);
   displayedFiles.value = displayedFiles.value.map(clearCurrent);
   file.current_object = true;
   currentObject.value = file;
@@ -159,9 +157,6 @@ async function onClickCollection(file) {
   displayedPath.value = file.path.replace(hiddenRoot.value, '');
   displayedFolders.value.push({ id: file.id, path: file.path, name: file.name });
   isLoadingFiles.value = false;
-  if (displayedFiles.value.length > 0) {
-    await ProjectComponent.dispatchProjectStateChange(displayedFiles.value[0]);
-  }
 }
 
 async function onClickBreadcrumb(path) {
@@ -171,12 +166,6 @@ async function onClickBreadcrumb(path) {
   displayedFolders.value = displayedFolders.value.slice(0, pathIndex + 1);
   isLoadingFiles.value = false;
 }
-
-onMounted(async () => {
-  if (props.files.length > 0) {
-    await ProjectComponent.dispatchProjectStateChange(props.files[0]);
-  }
-});
 </script>
 <style>
 @import 'variables.css';

--- a/app/javascript/vue_components/project_item.vue
+++ b/app/javascript/vue_components/project_item.vue
@@ -4,18 +4,37 @@
       <header class="card-title lead fw-bold px-2 my-0">Details</header>
       <div class="project-file-details inline-container bg-body rounded p-2">
         <div class="inline-container">
-          <header class="fw-semibold" data-attribute-name="fileName">File Name</header>
+          <header
+            v-if="displayedObject.collection"
+            class="fw-semibold"
+            data-attribute-name="fileName"
+          >
+            Folder Name
+          </header>
+          <header v-else class="fw-semibold" data-attribute-name="fileName">File Name</header>
           <p class="project-file-attribute font-monospace" data-attribute-name="fileName">
             {{ displayedObject.name }}
           </p>
         </div>
-        <div class="inline-container">
+        <div v-if="displayedObject.collection" class="inline-container">
+          <header class="fw-semibold" data-attribute-name="folderSize">Folder Size</header>
+          <p class="project-file-attribute font-monospace" data-attribute-name="folderSize">
+            {{ displayedObject.folder_size }}
+          </p>
+        </div>
+        <div v-else class="inline-container">
           <header class="fw-semibold" data-attribute-name="fileSize">File Size</header>
           <p class="project-file-attribute font-monospace" data-attribute-name="fileSize">
             {{ displayedObject.size }}
           </p>
         </div>
-        <div class="inline-container">
+        <div v-if="displayedObject.collection" class="inline-container">
+          <header class="fw-semibold" data-attribute-name="itemCount">Item Count</header>
+          <p class="project-file-attribute font-monospace" data-attribute-name="itemCount">
+            {{ displayedObject.asset_count }}
+          </p>
+        </div>
+        <div v-if="!displayedObject.collection" class="inline-container">
           <header class="fw-semibold" data-attribute-name="fileType">File Type</header>
           <p class="project-file-attribute font-monospace" data-attribute-name="fileType">
             {{ displayedObject.type }}
@@ -48,7 +67,7 @@
 import { ref, watch } from 'vue';
 import CopyPath from './copy_path.vue';
 
-defineOptions({ name: 'Project' });
+defineOptions({ name: 'ProjectItem' });
 const props = defineProps({
   currentObject: {
     type: Object,

--- a/app/models/mediaflux/asset.rb
+++ b/app/models/mediaflux/asset.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 module Mediaflux
   class Asset
-    attr_accessor :id, :path, :collection, :size
+    attr_accessor :id, :path, :collection, :size, :collection_count, :file_count, :folder_size
 
-    def initialize(id:, name:, collection:, path: nil, last_modified_mf: nil, size: nil)
+    def initialize(id:, name:, collection:, path: nil, last_modified_mf: nil, size: nil, collection_count: nil, file_count: nil, folder_size: nil)
       @id = id
       @name = name
       @path = path
       @collection = collection
       @size = size
       @last_modified_mf = last_modified_mf
+      @collection_count = collection_count
+      @file_count = file_count
+      @folder_size = folder_size
     end
 
     def name
@@ -74,8 +77,14 @@ module Mediaflux
                              collection: collection,
                              size: size,
                              last_modified: last_modified,
-                             last_modified_mf: @last_modified_mf
+                             last_modified_mf: @last_modified_mf,
+                             asset_count: asset_count,
+                             folder_size: folder_size
                            })
+    end
+
+    def asset_count
+      collection_count + file_count
     end
   end
 end

--- a/app/models/mediaflux/iterator_request.rb
+++ b/app/models/mediaflux/iterator_request.rb
@@ -88,17 +88,24 @@ module Mediaflux
       def parse_get_values(xml)
         files = []
         xml.xpath("/response/reply/result/asset").each do |node|
-          file = Mediaflux::Asset.new(
-            id: node.xpath("./@id").text,
-            name: node.xpath("./name").text,
-            path: node.xpath("./path").text,
-            collection: node.xpath("./collection").text == "true",
-            size: node.xpath("./total-size").text.to_i,
-            last_modified_mf: node.xpath("mtime").text
-          )
+          file = Mediaflux::Asset.new(**parse_asset_attribute(node))
           files << file
         end
         files
+      end
+
+      def parse_asset_attribute(node)
+        {
+          id: node.xpath("./@id").text,
+          name: node.xpath("./name").text,
+          path: node.xpath("./path").text,
+          collection: node.xpath("./collection").text == "true",
+          size: node.xpath("./total-size").text.to_i,
+          last_modified_mf: node.xpath("mtime").text,
+          collection_count: node.xpath("./collection-count").text.to_i,
+          file_count: node.xpath("./file-count").text.to_i,
+          folder_size: node.xpath("./folder-size").text.to_i
+        }
       end
   end
 end

--- a/app/models/mediaflux/query_request.rb
+++ b/app/models/mediaflux/query_request.rb
@@ -78,6 +78,9 @@ module Mediaflux
         declare_get_value_field(xml, "content/@total-size", "total-size")
         declare_get_value_field(xml, "mtime", "mtime")
         declare_get_value_field(xml, "@collection", "collection")
+        declare_get_value_field(xml, "collection/statistics/non-collections", "file-count")
+        declare_get_value_field(xml, "collection/statistics/collections", "collection-count")
+        declare_get_value_field(xml, "collection/statistics/total-size", "folder-size")
       end
 
       # Adds a single field declaration

--- a/app/presenters/project_file_show_presenter.rb
+++ b/app/presenters/project_file_show_presenter.rb
@@ -2,7 +2,7 @@
 class ProjectFileShowPresenter
   include ActiveSupport::NumberHelper
 
-  delegate "id", "name", "path", "size", "collection", :last_modified, to: :file
+  delegate "id", "name", "path", "size", "collection", :last_modified, :asset_count, :folder_size, to: :file
   attr_reader :file
 
   def initialize(project_file)
@@ -23,6 +23,10 @@ class ProjectFileShowPresenter
     number_to_human_size(size, precision: 2)
   end
 
+  def folder_size_human
+    number_to_human_size(folder_size, precision: 2)
+  end
+
   def to_hash
     {
       id: id,
@@ -31,7 +35,9 @@ class ProjectFileShowPresenter
       collection: collection,
       size: size_human,
       type: type,
-      last_modified: Time.zone.parse(last_modified).strftime("%m/%d/%Y")
+      last_modified: Time.zone.parse(last_modified).strftime("%m/%d/%Y"),
+      asset_count: asset_count,
+      folder_size: folder_size_human
     }
   end
 

--- a/spec/presenters/project_show_presenter_spec.rb
+++ b/spec/presenters/project_show_presenter_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe ProjectShowPresenter do
       expect(parsed.first["name"]).to eq("A0")
       expect(parsed.first["path"]).to eq("/princeton/tigerdata/RDSS/Query/CProject/A0")
       expect(parsed.first["size"]).to eq("10 Bytes")
+      expect(parsed.first["asset_count"]).to eq(0)
+      expect(parsed.first["folder_size"]).to eq("0 Bytes")
       expect(parsed.first["type"]).to eq("unknown")
       expect(parsed.first["name"]).to eq("A0")
       expect(parsed.last["collection"]).to be_truthy
@@ -72,6 +74,8 @@ RSpec.describe ProjectShowPresenter do
       expect(parsed.last["name"]).to eq("n_10000")
       expect(parsed.last["path"]).to eq("/princeton/tigerdata/RDSS/Query/CProject/n_10000")
       expect(parsed.last["size"]).to eq("0 Bytes")
+      expect(parsed.last["asset_count"]).to eq(10_000)
+      expect(parsed.last["folder_size"]).to eq("98 KB")
       expect(parsed.last["type"]).to eq("collection")
     end
   end

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -154,6 +154,20 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
             have_css("p", text: last_modified_date)
             expect(page).to have_css(".sizer") # check that the copy path button is present
           end
+          page.all("tr")[6].click
+          within(".project-file") do
+            expect(page).to have_css("header", text: "Folder Name")
+            expect(page).to have_css("p", text: "parent_1")
+            expect(page).to have_css("header", text: "Folder Size")
+            expect(page).to have_css("p", text: "950 Bytes")
+            expect(page).to have_css("header", text: "Item Count")
+            expect(page).to have_css("p", text: "97")
+            expect(page).to have_css("header", text: "Location")
+            have_css("p", text: "/tigerdata/RDSS/Query/CProject/parent_1")
+            expect(page).to have_css("header", text: "Modified Date")
+            have_css("p", text: last_modified_date)
+            expect(page).to have_css(".sizer") # check that the copy path button is present
+          end
         end
 
         it "displays an the file warning indicator when appropriate" do
@@ -200,6 +214,7 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
       end
 
       context "when the new_file_details feature is turned on" do
+        let(:last_modified) { Time.current.in_time_zone("America/New_York").iso8601 }
         before do
           test_strategy.switch!(:new_file_details, true)
         end
@@ -212,11 +227,8 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
         context "with files exceeding the project file display limit" do
           before do
             iterator_request = instance_double("Mediaflux::IteratorRequest")
-            file_asset = instance_double("Mediaflux::Asset", id: "123", name: "file1.txt", path: "path/to/file1.txt")
-            allow(file_asset).to receive(:path_only).and_return("path/to/file1.txt")
-            allow(file_asset).to receive(:size).and_return(100)
-            allow(file_asset).to receive(:last_modified).and_return(Time.current.in_time_zone("America/New_York").iso8601)
-            allow(file_asset).to receive(:collection).and_return(false)
+            file_asset = instance_double("Mediaflux::Asset", id: "123", name: "file1.txt", path: "path/to/file1.txt", path_only: "path/to/file1.txt",
+                                                             collection: false, size: 100, last_modified: last_modified, folder_size: 0, asset_count: 0)
 
             files = [file_asset] * (Rails.configuration.project_file_display_limit + 1)
             allow(iterator_request).to receive(:result).and_return(
@@ -243,14 +255,10 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
         end
 
         context "with files persisted for the project" do
-          let(:last_modified) { Time.current.in_time_zone("America/New_York").iso8601 }
           before do
             iterator_request = instance_double("Mediaflux::IteratorRequest")
-            file_asset = instance_double("Mediaflux::Asset", id: "123", name: "file1.txt", path: "path/to/file1.txt")
-            allow(file_asset).to receive(:path_only).and_return("path/to/file1.txt")
-            allow(file_asset).to receive(:size).and_return(100)
-            allow(file_asset).to receive(:last_modified).and_return(last_modified)
-            allow(file_asset).to receive(:collection).and_return(false)
+            file_asset = instance_double("Mediaflux::Asset", id: "123", name: "file1.txt", path: "path/to/file1.txt", path_only: "path/to/file1.txt",
+                                                             collection: false, size: 100, last_modified: last_modified, folder_size: 0, asset_count: 0)
 
             files = [file_asset]
             allow(iterator_request).to receive(:result).and_return(


### PR DESCRIPTION
Pulled the information from Mediaflux for folder size and item count

Also cleaned up references to ProjectComponent

Renames project.vue project_item.vue

## New display for a collection

<img width="1167" height="486" alt="Screenshot 2026-05-05 at 7 58 06 AM" src="https://github.com/user-attachments/assets/4b3a38d2-bd34-477c-8cb2-8da028ac7d83" />


## Figma display for a collection
<img width="708" height="399" alt="Screenshot 2026-05-05 at 8 06 22 AM" src="https://github.com/user-attachments/assets/a2cd7e2b-7b18-4460-bfa3-389390f672ad" />


## Old display for a collection

<img width="1147" height="538" alt="Screenshot 2026-05-05 at 8 04 37 AM" src="https://github.com/user-attachments/assets/f9b19a2c-aba6-4455-8731-6bdfc4ba42dc" />
