### PR TITLE
Switching Globus links for documentation

### DIFF
--- a/app/views/projects/_globus_access.html.erb
+++ b/app/views/projects/_globus_access.html.erb
@@ -10,13 +10,13 @@
             </div>
             <div class="globus-p1">
                 Select 'Yes' if the project will need its own
-                <a class="globus-link" href="https://researchcomputing.princeton.edu/document/6796" target="_blank">
+                <a class="globus-link" href="https://tigerdata.princeton.edu/get-started/accessing-tigerdata#Globus" target="_blank">
                 Globus endpoint <span class="img"><%= image_tag "open-icon.svg", alt: "" %></span>
                 </a> for high bandwidth data transfers.
             </div>
             <div class="globus-p2">
                 You or your Data Manager will need an
-                <a class="globus-link" href="https://docs.globus.org/guides/tutorials/manage-files/transfer-files/" target="_blank">
+                <a class="globus-link" href="https://researchcomputing.princeton.edu/document/6796" target="_blank">
                 active Globus account <span class="img"><%= image_tag "open-icon.svg", alt: "" %></span>
                 </a> to proceed.
             </div>


### PR DESCRIPTION
Per feedback from Dominique today in a meeting, the Globus documentation links in the modal need to go to these locations.