### PR TITLE
Changing mediaflux id from in to bigint

### DIFF
--- a/db/migrate/20260804171205_mediaflux_id_to_bigint.rb
+++ b/db/migrate/20260804171205_mediaflux_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class MediafluxIdToBigint < ActiveRecord::Migration[8.1]
+  def change
+    change_column :projects, :mediaflux_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_182404) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_171205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -74,7 +74,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_182404) do
 
   create_table "projects", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "mediaflux_id"
+    t.bigint "mediaflux_id"
     t.jsonb "metadata_json"
     t.datetime "updated_at", null: false
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
     # ActiveModel::RangeError:
     # 2224309126 is out of range for ActiveModel::Type::Integer with limit 4 bytes
     it "can handle at least a number larger than 4 bytes" do
-      project = FactoryBot.create(:project, mediaflux_id: 2224309126)
+      project = FactoryBot.create(:project, mediaflux_id: 2_224_309_126)
       expect(project.id).not_to be_nil
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
   let(:user2) { FactoryBot.create(:user, uid: "libtigerdatadev", mediaflux_session: SystemUser.mediaflux_session) }
   let!(:sponsor_and_data_manager_user) { FactoryBot.create(:sponsor_and_data_manager, uid: "tigerdatatester", mediaflux_session: SystemUser.mediaflux_session) }
 
+  describe "the mediaflux id" do
+    # This solves https://github.com/pulibrary/tigerdata-app/issues/2830
+    # ActiveModel::RangeError:
+    # 2224309126 is out of range for ActiveModel::Type::Integer with limit 4 bytes
+    it "can handle at least a number larger than 4 bytes" do
+      project = FactoryBot.create(:project, mediaflux_id: 2224309126)
+      expect(project.id).not_to be_nil
+    end
+  end
+
   describe "project lists" do
     let(:test_user) { sponsor_and_data_manager_user }
     before do


### PR DESCRIPTION
This will allow the mediaflux id to get much larger than it currently is

refs #2830 